### PR TITLE
Add sessionAffinity field for services

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
@@ -119,6 +119,7 @@ public class Sample3Test implements SampleTest {
         Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), pizzaSvc.getSpec().getType());
         Assert.assertEquals(1, pizzaSvc.getSpec().getPorts().size());
         Assert.assertEquals(9099, pizzaSvc.getSpec().getPorts().get(0).getPort().intValue());
+        Assert.assertEquals("ClientIP", pizzaSvc.getSpec().getSessionAffinity());
 
         // Assert burgerSvc
         Assert.assertNotNull(burgerSvc);

--- a/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
@@ -75,15 +75,22 @@ public type DeploymentConfiguration record {
 # @kubernetes:Deployment annotation to configure deplyoment yaml.
 public annotation<service, endpoint> Deployment DeploymentConfiguration;
 
+@final public SessionAffinity NONE = "None";
+@final public SessionAffinity CLIENT_IP = "ClientIP";
+
+# Session affinity field for kubernetes services.
+public type SessionAffinity "None"|"ClientIP";
 
 # Kubernetes service configuration.
 #
 # + name - Name of the service
 # + labels - Map of labels for deployment
+# + sessionAffinity - Session affinity for pods
 # + serviceType - Service type of the service
 public type ServiceConfiguration record {
     string name;
     map labels;
+    SessionAffinity? sessionAffinity;
     string serviceType;
 };
 

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/ServiceHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/ServiceHandler.java
@@ -59,6 +59,7 @@ public class ServiceHandler extends AbstractArtifactHandler {
                 .withNewTargetPort(serviceModel.getPort())
                 .endPort()
                 .addToSelector(KubernetesConstants.KUBERNETES_SELECTOR_KEY, serviceModel.getSelector())
+                .withSessionAffinity(serviceModel.getSessionAffinity())
                 .withType(serviceModel.getServiceType())
                 .endSpec()
                 .build();

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/ServiceModel.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/ServiceModel.java
@@ -26,10 +26,12 @@ import java.util.Map;
  * Kubernetes service annotations model class.
  */
 public class ServiceModel extends KubernetesModel {
+    
     private Map<String, String> labels;
     private String serviceType;
     private int port;
     private String selector;
+    private String sessionAffinity;
 
     public ServiceModel() {
         serviceType = KubernetesConstants.ServiceType.ClusterIP.name();
@@ -71,15 +73,24 @@ public class ServiceModel extends KubernetesModel {
     public void setSelector(String selector) {
         this.selector = selector;
     }
-
+    
+    public String getSessionAffinity() {
+        return sessionAffinity;
+    }
+    
+    public void setSessionAffinity(String sessionAffinity) {
+        this.sessionAffinity = sessionAffinity;
+    }
+    
     @Override
     public String toString() {
         return "ServiceModel{" +
-                "name='" + getName() + '\'' +
-                ", labels=" + labels +
-                ", serviceType='" + serviceType + '\'' +
-                ", port=" + port +
-                ", selector='" + selector + '\'' +
-                '}';
+               "name='" + getName() + '\'' +
+               ", labels=" + labels +
+               ", serviceType='" + serviceType + '\'' +
+               ", sessionAffinity='" + sessionAffinity + '\'' +
+               ", port=" + port +
+               ", selector='" + selector + '\'' +
+               '}';
     }
 }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
@@ -119,6 +119,9 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
                                 "@kubernetes annotations.");
                     }
                     break;
+                case sessionAffinity:
+                    serviceModel.setSessionAffinity(annotationValue);
+                    break;
                 default:
                     break;
             }
@@ -133,6 +136,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         name,
         labels,
         serviceType,
-        port
+        port,
+        sessionAffinity
     }
 }

--- a/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/handlers/KubernetesServiceGeneratorTests.java
+++ b/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/handlers/KubernetesServiceGeneratorTests.java
@@ -40,6 +40,7 @@ public class KubernetesServiceGeneratorTests {
     private final String serviceName = "MyService";
     private final String selector = "hello";
     private final String serviceType = "NodePort";
+    private final String sessionAffinity = "ClientIP";
     private final int port = 9090;
 
     @Test
@@ -49,6 +50,7 @@ public class KubernetesServiceGeneratorTests {
         serviceModel.setPort(port);
         serviceModel.setServiceType(serviceType);
         serviceModel.setSelector(selector);
+        serviceModel.setSessionAffinity(sessionAffinity);
         Map<String, String> labels = new HashMap<>();
         labels.put(KubernetesConstants.KUBERNETES_SELECTOR_KEY, selector);
         serviceModel.setLabels(labels);
@@ -72,6 +74,7 @@ public class KubernetesServiceGeneratorTests {
         Assert.assertEquals(selector, service.getMetadata().getLabels().get(KubernetesConstants
                 .KUBERNETES_SELECTOR_KEY));
         Assert.assertEquals(serviceType, service.getSpec().getType());
+        Assert.assertEquals(sessionAffinity, service.getSpec().getSessionAffinity());
         Assert.assertEquals(1, service.getSpec().getPorts().size());
         Assert.assertEquals(port, service.getSpec().getPorts().get(0).getPort().intValue());
 

--- a/samples/sample3/foodstore.bal
+++ b/samples/sample3/foodstore.bal
@@ -7,7 +7,9 @@ import ballerinax/kubernetes;
     path:"/pizzastore",
     targetPath:"/"
 }
-@kubernetes:Service {}
+@kubernetes:Service {
+    sessionAffinity: "ClientIP"
+}
 endpoint http:Listener pizzaEP {
     port:9099
 };


### PR DESCRIPTION
## Purpose
> Add session affinity field for k8 services.
> Resolves https://github.com/ballerinax/kubernetes/issues/170

## Goals
> Allow changing session affinity.

## Approach
> Add new field for service annotations.