### PR TITLE
Fix setting port in service configuration.

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.kubernetes.test;
+
+import io.fabric8.docker.api.model.ImageInspect;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.ballerinax.kubernetes.KubernetesConstants;
+import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
+import org.ballerinax.kubernetes.utils.KubernetesUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
+import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+
+/**
+ * Test generating service artifacts.
+ */
+public class ServiceTest {
+    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("svc")
+            .toAbsolutePath().toString();
+    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
+    private final String dockerImage = "pizza-shop:latest";
+    
+    private final String selectorApp = "different-svc-ports";
+    private Service service;
+    private Ingress ingress;
+    
+    @BeforeClass
+    public void compileSample() throws IOException, InterruptedException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "different-svc-ports.bal"), 0);
+        File yamlFile = new File(targetPath + File.separator + "different-svc-ports.yaml");
+        Assert.assertTrue(yamlFile.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
+        for (HasMetadata data : k8sItems) {
+            switch (data.getKind()) {
+                case "Service":
+                    service = (Service) data;
+                    break;
+                case "Ingress":
+                    ingress = (Ingress) data;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    
+    /**
+     * Validate generated service yaml.
+     */
+    @Test
+    public void validateK8SService() {
+        Assert.assertNotNull(service);
+        Assert.assertEquals("hello", service.getMetadata().getName());
+        Assert.assertEquals(selectorApp, service.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY));
+        Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), service.getSpec().getType());
+        Assert.assertEquals(1, service.getSpec().getPorts().size());
+        Assert.assertEquals(8080, service.getSpec().getPorts().get(0).getPort().intValue());
+        Assert.assertEquals(9090, service.getSpec().getPorts().get(0).getTargetPort().getIntVal().intValue());
+    }
+    
+    /**
+     * Validate generated ingress yaml.
+     */
+    @Test(dependsOnMethods = {"validateK8SService"})
+    public void validateIngress() {
+        Assert.assertNotNull(ingress);
+        Assert.assertEquals("helloep-ingress", ingress.getMetadata().getName());
+        Assert.assertEquals(selectorApp, ingress.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY));
+        Assert.assertEquals("abc.com", ingress.getSpec().getRules().get(0).getHost());
+        Assert.assertEquals("/", ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
+        Assert.assertEquals(service.getMetadata().getName(), ingress.getSpec().getRules().get(0).getHttp().getPaths()
+                .get(0).getBackend()
+                .getServiceName());
+        Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), ingress.getSpec().getRules()
+                .get(0).getHttp().getPaths().get(0).getBackend()
+                .getServicePort().getIntVal().intValue());
+        Assert.assertEquals(2, ingress.getMetadata().getAnnotations().size());
+    }
+    
+    @Test
+    public void validateDockerfile() {
+        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        Assert.assertTrue(dockerFile.exists());
+    }
+    
+    @Test
+    public void validateDockerImage() {
+        ImageInspect imageInspect = getDockerImage(dockerImage);
+        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
+        Assert.assertEquals("9090/tcp", imageInspect.getContainerConfig().getExposedPorts().keySet().toArray()[0]);
+    }
+    
+    @AfterClass
+    public void cleanUp() throws KubernetesPluginException {
+        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesTestUtils.deleteDockerImage(dockerImage);
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/svc/different-svc-ports.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/different-svc-ports.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerinax/kubernetes;
+
+@kubernetes:Deployment {
+    image: "pizza-shop:latest",
+    singleYAML: true
+}
+@kubernetes:Ingress {
+    hostname: "abc.com"
+}
+@kubernetes:Service {
+    name: "hello",
+    port: 8080
+}
+endpoint http:Listener helloEP {
+    port: 9090
+};
+
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service<http:Service> helloWorld bind helloEP {
+    sayHello(endpoint outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        _ = outboundEP->respond(response);
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/testng.xml
+++ b/kubernetes-extension-test/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
             <class name="org.ballerinax.kubernetes.test.ResourceQuotaTest"/>
             <class name="org.ballerinax.kubernetes.test.JobTest"/>
             <class name="org.ballerinax.kubernetes.test.MainFunctionDeploymentTest"/>
+            <class name="org.ballerinax.kubernetes.test.ServiceTest"/>
         </classes>
     </test>
 

--- a/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
@@ -167,7 +167,7 @@ public type ServiceType "NodePort"|"ClusterIP"|"LoadBalancer";
 public type ServiceConfiguration record {
     string name;
     map<string>? labels;
-    int port;
+    int? port;
     SessionAffinity? sessionAffinity;
     ServiceType? serviceType;
     !...

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/ServiceHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/ServiceHandler.java
@@ -86,7 +86,7 @@ public class ServiceHandler extends AbstractArtifactHandler {
             serviceModel.addLabel(KubernetesConstants.KUBERNETES_SELECTOR_KEY, balxFileName);
             serviceModel.setSelector(balxFileName);
             generate(serviceModel);
-            deploymentModel.addPort(serviceModel.getPort());
+            deploymentModel.addPort(serviceModel.getTargetPort());
             OUT.print("\t@kubernetes:Service \t\t\t - complete " + count + "/" + serviceModels.size() + "\r");
         }
     }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/ServiceHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/ServiceHandler.java
@@ -56,7 +56,7 @@ public class ServiceHandler extends AbstractArtifactHandler {
                 .addNewPort()
                 .withProtocol(KubernetesConstants.KUBERNETES_SVC_PROTOCOL)
                 .withPort(serviceModel.getPort())
-                .withNewTargetPort(serviceModel.getPort())
+                .withNewTargetPort(serviceModel.getTargetPort())
                 .endPort()
                 .addToSelector(KubernetesConstants.KUBERNETES_SELECTOR_KEY, serviceModel.getSelector())
                 .withSessionAffinity(serviceModel.getSessionAffinity())

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/ServiceModel.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/ServiceModel.java
@@ -29,13 +29,16 @@ public class ServiceModel extends KubernetesModel {
     
     private Map<String, String> labels;
     private String serviceType;
-    private int port = -1;
+    private int port;
+    private int targetPort;
     private String selector;
     private String sessionAffinity;
 
     public ServiceModel() {
         serviceType = KubernetesConstants.ServiceType.ClusterIP.name();
         labels = new HashMap<>();
+        port = -1;
+        targetPort = -1;
     }
 
     public Map<String, String> getLabels() {
@@ -65,7 +68,15 @@ public class ServiceModel extends KubernetesModel {
     public void setPort(int port) {
         this.port = port;
     }
-
+    
+    public int getTargetPort() {
+        return targetPort;
+    }
+    
+    public void setTargetPort(int targetPort) {
+        this.targetPort = targetPort;
+    }
+    
     public String getSelector() {
         return selector;
     }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
@@ -52,7 +52,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         }
         List<BLangRecordLiteral.BLangRecordKeyValue> endpointConfig =
                 ((BLangRecordLiteral) ((BLangEndpoint) endpointNode).configurationExpr).getKeyValuePairs();
-        // If service annotation port is not empty, then endpoint port used is used for the k8s svc target port while
+        // If service annotation port is not empty, then endpoint port is used for the k8s svc target port while
         // service annotation port is used for k8s port.
         // If service annotation port is empty, then endpoint port is used for both port and target port of the k8s
         // svc.
@@ -78,7 +78,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         }
         List<BLangRecordLiteral.BLangRecordKeyValue> endpointConfig =
                 ((BLangRecordLiteral) anonymousEndpoint).getKeyValuePairs();
-        // If service annotation port is not empty, then endpoint port used is used for the k8s svc target port while
+        // If service annotation port is not empty, then endpoint port is used for the k8s svc target port while
         // service annotation port is used for k8s port.
         // If service annotation port is empty, then endpoint port is used for both port and target port of the k8s
         // svc.

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
@@ -52,9 +52,14 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         }
         List<BLangRecordLiteral.BLangRecordKeyValue> endpointConfig =
                 ((BLangRecordLiteral) ((BLangEndpoint) endpointNode).configurationExpr).getKeyValuePairs();
+        // If service annotation port is not empty, then endpoint port used is used for the k8s svc target port while
+        // service annotation port is used for k8s port.
+        // If service annotation port is empty, then endpoint port is used for both port and target port of the k8s
+        // svc.
         if (serviceModel.getPort() == -1) {
             serviceModel.setPort(extractPort(endpointConfig));
         }
+        serviceModel.setTargetPort(extractPort(endpointConfig));
         KubernetesContext.getInstance().getDataHolder().addBEndpointToK8sServiceMap(endpointNode.getName().getValue()
                 , serviceModel);
     }
@@ -73,7 +78,14 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         }
         List<BLangRecordLiteral.BLangRecordKeyValue> endpointConfig =
                 ((BLangRecordLiteral) anonymousEndpoint).getKeyValuePairs();
-        serviceModel.setPort(extractPort(endpointConfig));
+        // If service annotation port is not empty, then endpoint port used is used for the k8s svc target port while
+        // service annotation port is used for k8s port.
+        // If service annotation port is empty, then endpoint port is used for both port and target port of the k8s
+        // svc.
+        if (serviceModel.getPort() == -1) {
+            serviceModel.setPort(extractPort(endpointConfig));
+        }
+        serviceModel.setTargetPort(extractPort(endpointConfig));
         KubernetesContext.getInstance().getDataHolder().addBEndpointToK8sServiceMap(serviceNode.getName().getValue(),
                 serviceModel);
     }


### PR DESCRIPTION
## Purpose
> Setting port in @kubernetes:Service annotation would make using that port for ingress and service and the endpoint port used for targetPort and docker instance.

## Goals
> Allowing setting different port and targetPort in @kubernetes:Service annotation.

## Approach
> Introduce new property as targetPort in service model.