### PR TITLE
Allow annotations for @kubernetes:Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Annotation based kubernetes extension implementation for ballerina.
 |name|Name of the deployment|\<outputfilename\>-deployment|
 |namespace|Namespace of the deployment|null|
 |labels|Labels for deployment|"app: \<outputfilename\>"|
+|annotations|Annotations for deployment|{}|
+|podAnnotations|Pod annotations|{}|
 |replicas|Number of replicas|1|
 |dependsOn|Endpoints this deployment Depends on|null|
 |enableLiveness|Enable or disable liveness probe|false|

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
@@ -75,6 +75,36 @@ public class DeploymentTest {
     }
     
     /**
+     * Build bal file with deployment having pod annotations.
+     *
+     * @throws IOException               Error when loading the generated yaml.
+     * @throws InterruptedException      Error when compiling the ballerina file.
+     * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
+     */
+    @Test
+    public void podAnnotationsTest() throws IOException, InterruptedException, KubernetesPluginException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "pod_annotations.bal"), 0);
+        
+        // Check if docker image exists and correct
+        validateDockerfile();
+        validateDockerImage();
+        
+        // Validate deployment yaml
+        File deploymentYAML = Paths.get(targetPath).resolve("pod_annotations_deployment.yaml").toFile();
+        Assert.assertTrue(deploymentYAML.exists());
+        Deployment deployment = KubernetesHelper.loadYaml(deploymentYAML);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getMetadata().getAnnotations().size(), 2,
+                "Invalid number of annotations found.");
+        Assert.assertEquals(deployment.getSpec().getTemplate().getMetadata().getAnnotations().get("anno1"), "anno1Val",
+                "Invalid annotation found.");
+        Assert.assertEquals(deployment.getSpec().getTemplate().getMetadata().getAnnotations().get("anno2"), "anno2Val",
+                "Invalid annotation found.");
+        
+        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesTestUtils.deleteDockerImage(dockerImage);
+    }
+    
+    /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.kubernetes.test;
+
+import io.fabric8.docker.api.model.ImageInspect;
+import io.fabric8.kubernetes.api.KubernetesHelper;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
+import org.ballerinax.kubernetes.utils.KubernetesUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
+import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+
+/**
+ * Test creating kubernetes deployment artifacts.
+ */
+public class DeploymentTest {
+    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("deployment")
+            .toAbsolutePath().toString();
+    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
+    private final String dockerImage = "pizza-shop:latest";
+    
+    /**
+     * Build bal file with deployment having annotations.
+     *
+     * @throws IOException               Error when loading the generated yaml.
+     * @throws InterruptedException      Error when compiling the ballerina file.
+     * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
+     */
+    @Test
+    public void annotationsTest() throws IOException, InterruptedException, KubernetesPluginException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "dep-annotations.bal"), 0);
+        
+        // Check if docker image exists and correct
+        validateDockerfile();
+        validateDockerImage();
+        
+        // Validate deployment yaml
+        File deploymentYAML = Paths.get(targetPath).resolve("dep-annotations_deployment.yaml").toFile();
+        Assert.assertTrue(deploymentYAML.exists());
+        Deployment deployment = KubernetesHelper.loadYaml(deploymentYAML);
+        Assert.assertEquals(deployment.getMetadata().getAnnotations().size(), 2,
+                "Invalid number of annotations found.");
+        Assert.assertEquals(deployment.getMetadata().getAnnotations().get("anno1"), "anno1Val",
+                "Invalid annotation found.");
+        Assert.assertEquals(deployment.getMetadata().getAnnotations().get("anno2"), "anno2Val",
+                "Invalid annotation found.");
+        
+        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesTestUtils.deleteDockerImage(dockerImage);
+    }
+    
+    /**
+     * Validate if Dockerfile is created.
+     */
+    public void validateDockerfile() {
+        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        Assert.assertTrue(dockerFile.exists());
+    }
+    
+    /**
+     * Validate contents of the Dockerfile.
+     */
+    public void validateDockerImage() {
+        ImageInspect imageInspect = getDockerImage(dockerImage);
+        Assert.assertNotEquals(imageInspect, null, "Image not found");
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/deployment/dep-annotations.bal
+++ b/kubernetes-extension-test/src/test/resources/deployment/dep-annotations.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerinax/kubernetes;
+
+@kubernetes:Deployment {
+    image: "pizza-shop:latest",
+    annotations: {
+        anno1: "anno1Val",
+        anno2: "anno2Val"
+    }
+}
+@kubernetes:Ingress {
+    hostname: "abc.com"
+}
+@kubernetes:Service {
+    name: "hello",
+    port: 8080
+}
+endpoint http:Listener helloEP {
+    port: 9090
+};
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service<http:Service> helloWorld bind helloEP {
+    sayHello(endpoint outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        _ = outboundEP->respond(response);
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/deployment/pod_annotations.bal
+++ b/kubernetes-extension-test/src/test/resources/deployment/pod_annotations.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerinax/kubernetes;
+
+@kubernetes:Deployment {
+    image: "pizza-shop:latest",
+    podAnnotations: {
+        anno1: "anno1Val",
+        anno2: "anno2Val"
+    }
+}
+@kubernetes:Ingress {
+    hostname: "abc.com"
+}
+@kubernetes:Service {
+    name: "hello",
+    port: 8080
+}
+endpoint http:Listener helloEP {
+    port: 9090
+};
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service<http:Service> helloWorld bind helloEP {
+    sayHello(endpoint outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        _ = outboundEP->respond(response);
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/testng.xml
+++ b/kubernetes-extension-test/src/test/resources/testng.xml
@@ -30,6 +30,7 @@
             <class name="org.ballerinax.kubernetes.test.JobTest"/>
             <class name="org.ballerinax.kubernetes.test.MainFunctionDeploymentTest"/>
             <class name="org.ballerinax.kubernetes.test.ServiceTest"/>
+            <class name="org.ballerinax.kubernetes.test.DeploymentTest"/>
             <class name="org.ballerinax.kubernetes.test.IstioGatewayTest"/>
             <class name="org.ballerinax.kubernetes.test.IstioVirtualServiceTest"/>
         </classes>

--- a/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
@@ -104,6 +104,7 @@ public type RestartPolicy "OnFailure"|"Always"|"Never";
 # + name - Name of the deployment
 # + namespace - Kubernetes namespace
 # + labels - Map of labels for deployment
+# + annotations - Map of annotations for deployment
 # + replicas - Number of replicas
 # + enableLiveness - Enable/Disable liveness probe
 # + livenessPort - Port to check the liveness
@@ -126,7 +127,8 @@ public type RestartPolicy "OnFailure"|"Always"|"Never";
 public type DeploymentConfiguration record {
     string name;
     string namespace;
-    map labels;
+    map<string> labels;
+    map<string> annotations;
     int replicas;
     boolean enableLiveness;
     int livenessPort;

--- a/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
@@ -105,6 +105,7 @@ public type RestartPolicy "OnFailure"|"Always"|"Never";
 # + namespace - Kubernetes namespace
 # + labels - Map of labels for deployment
 # + annotations - Map of annotations for deployment
+# + podAnnotations - Map of annotations for pods
 # + replicas - Number of replicas
 # + enableLiveness - Enable/Disable liveness probe
 # + livenessPort - Port to check the liveness
@@ -129,6 +130,7 @@ public type DeploymentConfiguration record {
     string namespace;
     map<string> labels;
     map<string> annotations;
+    map<string> podAnnotations;
     int replicas;
     boolean enableLiveness;
     int livenessPort;

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/DeploymentHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/DeploymentHandler.java
@@ -211,6 +211,7 @@ public class DeploymentHandler extends AbstractArtifactHandler {
                 .withNewTemplate()
                 .withNewMetadata()
                 .addToLabels(deploymentModel.getLabels())
+                .addToAnnotations(deploymentModel.getPodAnnotations())
                 .endMetadata()
                 .withNewSpec()
                 .withContainers(container)

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/DeploymentHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/DeploymentHandler.java
@@ -203,6 +203,7 @@ public class DeploymentHandler extends AbstractArtifactHandler {
                 .withNewMetadata()
                 .withName(deploymentModel.getName())
                 .withLabels(deploymentModel.getLabels())
+                .withAnnotations(deploymentModel.getAnnotations())
                 .withNamespace(dataHolder.getNamespace())
                 .endMetadata()
                 .withNewSpec()

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/DeploymentModel.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/DeploymentModel.java
@@ -34,6 +34,7 @@ import static org.ballerinax.kubernetes.KubernetesConstants.WINDOWS_DEFAULT_DOCK
  */
 public class DeploymentModel extends KubernetesModel {
     private Map<String, String> labels;
+    private Map<String, String> annotations;
     private int replicas;
     private boolean enableLiveness;
     private int livenessPort;
@@ -98,7 +99,15 @@ public class DeploymentModel extends KubernetesModel {
     public void setLabels(Map<String, String> labels) {
         this.labels = labels;
     }
-
+    
+    public Map<String, String> getAnnotations() {
+        return annotations;
+    }
+    
+    public void setAnnotations(Map<String, String> annotations) {
+        this.annotations = annotations;
+    }
+    
     public int getReplicas() {
         return replicas;
     }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/DeploymentModel.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/DeploymentModel.java
@@ -35,6 +35,7 @@ import static org.ballerinax.kubernetes.KubernetesConstants.WINDOWS_DEFAULT_DOCK
 public class DeploymentModel extends KubernetesModel {
     private Map<String, String> labels;
     private Map<String, String> annotations;
+    private Map<String, String> podAnnotations;
     private int replicas;
     private boolean enableLiveness;
     private int livenessPort;
@@ -106,6 +107,14 @@ public class DeploymentModel extends KubernetesModel {
     
     public void setAnnotations(Map<String, String> annotations) {
         this.annotations = annotations;
+    }
+    
+    public Map<String, String> getPodAnnotations() {
+        return podAnnotations;
+    }
+    
+    public void setPodAnnotations(Map<String, String> podAnnotations) {
+        this.podAnnotations = podAnnotations;
     }
     
     public int getReplicas() {

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/DeploymentAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/DeploymentAnnotationProcessor.java
@@ -87,6 +87,9 @@ public class DeploymentAnnotationProcessor extends AbstractAnnotationProcessor {
                 case annotations:
                     deploymentModel.setAnnotations(getMap(((BLangRecordLiteral) keyValue.valueExpr).keyValuePairs));
                     break;
+                case podAnnotations:
+                    deploymentModel.setPodAnnotations(getMap(((BLangRecordLiteral) keyValue.valueExpr).keyValuePairs));
+                    break;
                 case enableLiveness:
                     deploymentModel.setEnableLiveness(Boolean.valueOf(annotationValue));
                     break;
@@ -178,6 +181,7 @@ public class DeploymentAnnotationProcessor extends AbstractAnnotationProcessor {
         namespace,
         labels,
         annotations,
+        podAnnotations,
         replicas,
         enableLiveness,
         livenessPort,

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/DeploymentAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/DeploymentAnnotationProcessor.java
@@ -84,6 +84,9 @@ public class DeploymentAnnotationProcessor extends AbstractAnnotationProcessor {
                 case labels:
                     deploymentModel.setLabels(getMap(((BLangRecordLiteral) keyValue.valueExpr).keyValuePairs));
                     break;
+                case annotations:
+                    deploymentModel.setAnnotations(getMap(((BLangRecordLiteral) keyValue.valueExpr).keyValuePairs));
+                    break;
                 case enableLiveness:
                     deploymentModel.setEnableLiveness(Boolean.valueOf(annotationValue));
                     break;
@@ -174,6 +177,7 @@ public class DeploymentAnnotationProcessor extends AbstractAnnotationProcessor {
         name,
         namespace,
         labels,
+        annotations,
         replicas,
         enableLiveness,
         livenessPort,


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerinax/kubernetes/issues/205.

## Goals
> Allow annotations for deployments.

## Approach
> Add new field for annotations.bal. Update models, handlers and annotation processors.