### PR TITLE
Support single yaml for Istio artifacts.

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
@@ -204,7 +204,8 @@ public class IstioGatewayTest {
     
         Map<String, Object> spec = (Map<String, Object>) gateway.get("spec");
         Map<String, Object> selector = (Map<String, Object>) spec.get("selector");
-        Assert.assertEquals(selector.get("istio"), "ingressgateway", "Invalid selector.");
+        Assert.assertEquals(selector.get(KubernetesConstants.ISTIO_GATEWAY_SELECTOR), "ingressgateway",
+                "Invalid selector.");
     
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
@@ -405,7 +406,8 @@ public class IstioGatewayTest {
         
         Map<String, Object> spec = (Map<String, Object>) gateway.get("spec");
         Map<String, Object> selector = (Map<String, Object>) spec.get("selector");
-        Assert.assertEquals(selector.get("istio"), "ingressgateway", "Invalid selector.");
+        Assert.assertEquals(selector.get(KubernetesConstants.ISTIO_GATEWAY_SELECTOR), "ingressgateway",
+                "Invalid selector.");
         
         List<Map<String, Object>> servers = (List<Map<String, Object>>) spec.get("servers");
         Map<String, Object> server = servers.get(0);
@@ -448,7 +450,8 @@ public class IstioGatewayTest {
         
         Map<String, Object> spec = (Map<String, Object>) gateway.get("spec");
         Map<String, Object> selector = (Map<String, Object>) spec.get("selector");
-        Assert.assertEquals(selector.get("istio"), "ingressgateway", "Invalid selector.");
+        Assert.assertEquals(selector.get(KubernetesConstants.ISTIO_GATEWAY_SELECTOR), "ingressgateway",
+                "Invalid selector.");
         
         List<Map<String, Object>> servers = (List<Map<String, Object>>) spec.get("servers");
         Map<String, Object> server = servers.get(0);

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/istio/IstioGatewayHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/istio/IstioGatewayHandler.java
@@ -191,6 +191,7 @@ public class IstioGatewayHandler extends AbstractArtifactHandler {
             Yaml yamlProcessor = new Yaml(options);
             String gatewayYamlString = yamlProcessor.dump(gatewayYamlModel);
             
+            gatewayYamlString = "---\n" + gatewayYamlString;
             KubernetesUtils.writeToFile(gatewayYamlString, ISTIO_GATEWAY_FILE_POSTFIX + YAML);
         } catch (IOException e) {
             String errorMessage = "Error while generating yaml file for istio gateway: " + gatewayModel.getName();

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/istio/IstioVirtualServiceHandler.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/handlers/istio/IstioVirtualServiceHandler.java
@@ -136,7 +136,8 @@ public class IstioVirtualServiceHandler extends AbstractArtifactHandler {
         
             Yaml yamlProcessor = new Yaml(options);
             String vsYamlString = yamlProcessor.dump(vsYamlModel);
-        
+    
+            vsYamlString = "---\n" + vsYamlString;
             KubernetesUtils.writeToFile(vsYamlString, ISTIO_VIRTUAL_SERVICE_FILE_POSTFIX + YAML);
         } catch (IOException e) {
             String errorMessage = "Error while generating yaml file for istio virtual service: " + vsModel.getName();


### PR DESCRIPTION
## Purpose
> Istio artifacts generated could not be incorporated to a single yaml file. This allows having everything in one file.

## Goals
> Single yaml generation.

## Approach
> Add yaml file separator.
