### PR TITLE
Set default empty cmd args for deployment model

### DIFF
--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/DeploymentModel.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/DeploymentModel.java
@@ -92,6 +92,7 @@ public class DeploymentModel extends KubernetesModel {
         this.copyFiles = new HashSet<>();
         this.imagePullSecrets = new HashSet<>();
         this.singleYAML = false;
+        this.commandArgs = "";
     }
 
     public Map<String, String> getLabels() {


### PR DESCRIPTION
## Purpose
> Command args resolved to null which was wrong. Command args should be an empty string.

## Goals
> Fix issues.

## Approach
> Set empty command args value.