### PR TITLE
Updating docker client to spotify docker client

### DIFF
--- a/kubernetes-extension-test/.gitignore
+++ b/kubernetes-extension-test/.gitignore
@@ -1,0 +1,1 @@
+kubernetes/

--- a/kubernetes-extension-test/pom.xml
+++ b/kubernetes-extension-test/pom.xml
@@ -60,6 +60,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ballerinax.kubernetes</groupId>
             <artifactId>kubernetes-extension</artifactId>
         </dependency>

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
@@ -18,10 +18,11 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
+import com.spotify.docker.client.messages.ImageInfo;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -52,7 +53,8 @@ public class DeploymentTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void annotationsTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void annotationsTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "dep_annotations.bal"), 0);
         
         // Check if docker image exists and correct
@@ -82,7 +84,8 @@ public class DeploymentTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void podAnnotationsTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void podAnnotationsTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "pod_annotations.bal"), 0);
         
         // Check if docker image exists and correct
@@ -115,8 +118,8 @@ public class DeploymentTest {
     /**
      * Validate contents of the Dockerfile.
      */
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        ImageInfo imageInspect = getDockerImage(dockerImage);
         Assert.assertNotEquals(imageInspect, null, "Image not found");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/EnvVarTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/EnvVarTest.java
@@ -18,11 +18,11 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 /**
  * Test setting environment variables for deployments.
@@ -53,7 +53,8 @@ public class EnvVarTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void nameValueTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void nameValueTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "name_value.bal"), 0);
         
         // Check if docker image exists and correct
@@ -82,7 +83,8 @@ public class EnvVarTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void fieldRefTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void fieldRefTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "field_ref_value.bal"), 0);
         
         // Check if docker image exists and correct
@@ -115,7 +117,8 @@ public class EnvVarTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void secretKeyRefTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void secretKeyRefTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "secret_key_ref.bal"), 0);
         
         // Check if docker image exists and correct
@@ -152,7 +155,8 @@ public class EnvVarTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void resourceFieldRefTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void resourceFieldRefTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "resource_field_ref_value.bal"), 0);
         
         // Check if docker image exists and correct
@@ -187,7 +191,8 @@ public class EnvVarTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void configMapKeyRefTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void configMapKeyRefTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "config_map_key_ref.bal"), 0);
         
         // Check if docker image exists and correct
@@ -224,7 +229,8 @@ public class EnvVarTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void combinedTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void combinedTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "combination.bal"), 0);
         
         // Check if docker image exists and correct
@@ -290,9 +296,9 @@ public class EnvVarTest {
     /**
      * Validate contents of the Dockerfile.
      */
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9099/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
@@ -499,6 +499,6 @@ public class IstioGatewayTest {
     public void validateDockerImage() throws DockerTestException, InterruptedException {
         List<String> ports = getExposedPorts(this.dockerImage);
         Assert.assertEquals(ports.size(), 1);
-        Assert.assertEquals(ports.get(0), "9099/tcp");
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
@@ -18,9 +18,9 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -36,7 +36,7 @@ import java.util.Map;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 /**
  * Test cases for generating istio gateway artifacts.
@@ -58,7 +58,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void allFieldsTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void allFieldsTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "all_fields.bal"), 0);
 
         // Check if docker image exists and correct
@@ -127,7 +128,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void multipleServersTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void multipleServersTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "multiple_servers.bal"), 0);
 
         // Check if docker image exists and correct
@@ -188,7 +190,8 @@ public class IstioGatewayTest {
      * @throws InterruptedException Error when compiling the ballerina file.
      */
     @Test
-    public void noSelectorTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void noSelectorTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "no_selector.bal"), 0);
     
         // Check if docker image exists and correct
@@ -219,7 +222,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void noTLSHttpRedirect() throws IOException, InterruptedException, KubernetesPluginException {
+    public void noTLSHttpRedirect() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "no_tls_https_redirect.bal"), 0);
 
         // Check if docker image exists and correct
@@ -267,7 +271,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void tlsMutualTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void tlsMutualTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_mutual.bal"), 0);
 
         // Check if docker image exists and correct
@@ -333,7 +338,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void tlsSimpleTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void tlsSimpleTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_simple.bal"), 0);
         
         // Check if docker image exists and correct
@@ -386,7 +392,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void emptyAnnoForEndpointTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void emptyAnnoForEndpointTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "empty_annotation_ep.bal"), 0);
         
         // Check if docker image exists and correct
@@ -430,7 +437,8 @@ public class IstioGatewayTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void emptyAnnotationForSvcTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void emptyAnnotationForSvcTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "empty_annotation_svc.bal"), 0);
         
         // Check if docker image exists and correct
@@ -488,9 +496,9 @@ public class IstioGatewayTest {
     /**
      * Validate contents of the Dockerfile.
      */
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioVirtualServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioVirtualServiceTest.java
@@ -18,8 +18,8 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -35,7 +35,7 @@ import java.util.Map;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 /**
  * Test cases for generating istio virtual service artifacts.
@@ -57,7 +57,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void httpRouteTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void httpRouteTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_route.bal"), 0);
         
         // Check if docker image exists and correct
@@ -122,7 +123,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void httpMatchRequestTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void httpMatchRequestTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_match_request.bal"), 0);
         
         // Check if docker image exists and correct
@@ -171,7 +173,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void destinationWeightTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void destinationWeightTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "destination_weight.bal"), 0);
         
         // Check if docker image exists and correct
@@ -221,7 +224,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void destinationTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void destinationTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "destination.bal"), 0);
         
         // Check if docker image exists and correct
@@ -265,7 +269,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void httpRedirectTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void httpRedirectTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_redirect.bal"), 0);
         
         // Check if docker image exists and correct
@@ -311,7 +316,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void httpRetryTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void httpRetryTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_retry.bal"), 0);
         
         // Check if docker image exists and correct
@@ -358,7 +364,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void httpFaultInjectionTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void httpFaultInjectionTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_fault_injection.bal"), 0);
         
         // Check if docker image exists and correct
@@ -405,7 +412,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void corsPolicyTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void corsPolicyTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "cors_policy.bal"), 0);
         
         // Check if docker image exists and correct
@@ -458,7 +466,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void tlsRouteTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void tlsRouteTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_route.bal"), 0);
         
         // Check if docker image exists and correct
@@ -517,7 +526,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void tcpRouteTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void tcpRouteTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tcp_route.bal"), 0);
         
         // Check if docker image exists and correct
@@ -565,7 +575,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void emptyAnnotationTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void emptyAnnotationTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "empty_annotation.bal"), 0);
         
         // Check if docker image exists and correct
@@ -611,7 +622,8 @@ public class IstioVirtualServiceTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void useServiceAnnotationPortTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void useServiceAnnotationPortTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "svc_port.bal"), 0);
         
         // Check if docker image exists and correct
@@ -660,9 +672,9 @@ public class IstioVirtualServiceTest {
     /**
      * Validate contents of the Dockerfile.
      */
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioVirtualServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioVirtualServiceTest.java
@@ -675,6 +675,6 @@ public class IstioVirtualServiceTest {
     public void validateDockerImage() throws DockerTestException, InterruptedException {
         List<String> ports = getExposedPorts(this.dockerImage);
         Assert.assertEquals(ports.size(), 1);
-        Assert.assertEquals(ports.get(0), "9099/tcp");
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/JobTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/JobTest.java
@@ -18,12 +18,13 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
+import com.spotify.docker.client.messages.ImageInfo;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Job;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -44,14 +45,13 @@ public class JobTest {
     private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
     private final String dockerImage = "my-ballerina-job:1.0";
 
-
     @Test
-    public void testKubernetesJobGeneration() throws IOException, InterruptedException {
+    public void testKubernetesJobGeneration() throws IOException, InterruptedException, DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "ballerina_job.bal"), 0);
         File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
         Assert.assertTrue(dockerFile.exists());
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertNotNull(imageInspect.getContainerConfig());
+        ImageInfo imageInspect = getDockerImage(dockerImage);
+        Assert.assertNotNull(imageInspect.config());
         File jobYAML = new File(targetPath + File.separator + "ballerina_job_job.yaml");
         Job job = KubernetesHelper.loadYaml(jobYAML);
         Assert.assertEquals("ballerina-job-job", job.getMetadata().getName());
@@ -63,9 +63,8 @@ public class JobTest {
                 .getRestartPolicy());
     }
 
-
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/MainFunctionDeploymentTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/MainFunctionDeploymentTest.java
@@ -18,11 +18,12 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
+import com.spotify.docker.client.messages.ImageInfo;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -52,7 +53,8 @@ public class MainFunctionDeploymentTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void mainFuncDeploymentTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void mainFuncDeploymentTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "main_function.bal"), 0);
         
         // Check if docker image exists and correct
@@ -83,8 +85,8 @@ public class MainFunctionDeploymentTest {
     /**
      * Validate contents of the Dockerfile.
      */
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertNotEquals(imageInspect, null, "Image not found");
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        ImageInfo dockerImage = getDockerImage(this.dockerImage);
+        Assert.assertNotNull(dockerImage, "Image not found");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ResourceQuotaTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ResourceQuotaTest.java
@@ -18,10 +18,10 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -30,10 +30,11 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 /**
  * Test creating resource quotas.
@@ -51,7 +52,8 @@ public class ResourceQuotaTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void simpleQuotaTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void simpleQuotaTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "simple_quota.bal"), 0);
         
         // Check if docker image exists and correct
@@ -92,7 +94,8 @@ public class ResourceQuotaTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void quotaWithScopeTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void quotaWithScopeTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "quota_with_scope.bal"), 0);
         
         // Check if docker image exists and correct
@@ -130,7 +133,8 @@ public class ResourceQuotaTest {
      * @throws KubernetesPluginException Error when deleting the generated artifacts folder.
      */
     @Test
-    public void multipleQuotaTest() throws IOException, InterruptedException, KubernetesPluginException {
+    public void multipleQuotaTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "multiple_quotas.bal"), 0);
         
         // Check if docker image exists and correct
@@ -184,9 +188,9 @@ public class ResourceQuotaTest {
     /**
      * Validate contents of the Dockerfile.
      */
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9099/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
@@ -18,7 +18,6 @@
 
 package org.ballerinax.kubernetes.test;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
@@ -26,6 +25,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -41,7 +41,7 @@ import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 /**
  * Test generating service artifacts.
@@ -119,10 +119,10 @@ public class ServiceTest {
     }
     
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertEquals("9090/tcp", imageInspect.getContainerConfig().getExposedPorts().keySet().toArray()[0]);
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
     }
     
     /**
@@ -136,7 +136,7 @@ public class ServiceTest {
     }
     
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
@@ -122,7 +122,7 @@ public class ServiceTest {
     public void validateDockerImage() throws DockerTestException, InterruptedException {
         List<String> ports = getExposedPorts(this.dockerImage);
         Assert.assertEquals(ports.size(), 1);
-        Assert.assertEquals(ports.get(0), "9099/tcp");
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
     
     /**

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample10Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample10Test.java
@@ -18,7 +18,6 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -27,6 +26,7 @@ import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -36,10 +36,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample10Test implements SampleTest {
 
@@ -81,17 +82,17 @@ public class Sample10Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImageBurger() {
-        ImageInspect imageInspect = getDockerImage(burgerDockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9096/tcp"));
+    public void validateDockerImageBurger() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(burgerDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9096/tcp");
     }
 
     @Test
-    public void validateDockerImagePizza() {
-        ImageInspect imageInspect = getDockerImage(pizzaDockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9099/tcp"));
+    public void validateDockerImagePizza() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(pizzaDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
     }
 
     @Test
@@ -209,7 +210,7 @@ public class Sample10Test implements SampleTest {
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(pizzaDockerImage);
         KubernetesTestUtils.deleteDockerImage(burgerDockerImage);

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample11Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample11Test.java
@@ -18,12 +18,13 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
+import com.spotify.docker.client.messages.ImageInfo;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Job;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -56,9 +57,9 @@ public class Sample11Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertNotNull(imageInspect.getContainerConfig());
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        ImageInfo imageInspect = getDockerImage(dockerImage);
+        Assert.assertNotNull(imageInspect.config());
     }
 
     @Test
@@ -75,7 +76,7 @@ public class Sample11Test implements SampleTest {
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample12Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample12Test.java
@@ -18,12 +18,12 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -33,10 +33,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample12Test implements SampleTest {
 
@@ -56,10 +57,10 @@ public class Sample12Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @Test
@@ -84,7 +85,7 @@ public class Sample12Test implements SampleTest {
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample13Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample13Test.java
@@ -18,8 +18,8 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -29,10 +29,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample13Test implements SampleTest {
 
@@ -61,28 +62,28 @@ public class Sample13Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImageCoolDrink() {
-        ImageInspect imageInspect = getDockerImage(coolDrinkDockerImage);
-        Assert.assertEquals(imageInspect.getContainerConfig().getExposedPorts().size(), 1);
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImageCoolDrink() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(coolDrinkDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @Test
-    public void validateDockerImageDrinkStore() {
-        ImageInspect imageInspect = getDockerImage(drinkStoreDockerImage);
-        Assert.assertEquals(imageInspect.getContainerConfig().getExposedPorts().size(), 1);
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9091/tcp"));
+    public void validateDockerImageDrinkStore() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(drinkStoreDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9091/tcp");
     }
     
     @Test
-    public void validateDockerImageHotDrink() {
-        ImageInspect imageInspect = getDockerImage(hotDrinkDockerImage);
-        Assert.assertEquals(imageInspect.getContainerConfig().getExposedPorts().size(), 1);
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImageHotDrink() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(hotDrinkDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(drinkStoreDockerImage);
         KubernetesTestUtils.deleteDockerImage(coolDrinkDockerImage);

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample14Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample14Test.java
@@ -18,7 +18,6 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
@@ -28,6 +27,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -42,7 +42,7 @@ import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 
 public class Sample14Test implements SampleTest {
@@ -134,14 +134,14 @@ public class Sample14Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertEquals("9090/tcp", imageInspect.getContainerConfig().getExposedPorts().keySet().toArray()[0]);
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample15Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample15Test.java
@@ -18,10 +18,10 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -31,10 +31,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 
 public class Sample15Test implements SampleTest {
@@ -55,10 +56,10 @@ public class Sample15Test implements SampleTest {
     }
     
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
     
     @Test
@@ -85,7 +86,7 @@ public class Sample15Test implements SampleTest {
     }
     
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample16Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample16Test.java
@@ -18,12 +18,12 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -40,7 +40,7 @@ import java.util.Map;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample16Test implements SampleTest {
 
@@ -70,24 +70,24 @@ public class Sample16Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImageBookDetails() {
-        ImageInspect imageInspect = getDockerImage(bookDetailsDockerImage);
-        Assert.assertEquals(imageInspect.getContainerConfig().getExposedPorts().size(), 1);
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("8080/tcp"));
+    public void validateDockerImageBookDetails() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(bookDetailsDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "8080/tcp");
     }
 
     @Test
-    public void validateDockerImageBookReviews() {
-        ImageInspect imageInspect = getDockerImage(bookReviewsDockerImage);
-        Assert.assertEquals(imageInspect.getContainerConfig().getExposedPorts().size(), 1);
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("7070/tcp"));
+    public void validateDockerImageBookReviews() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(bookReviewsDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "7070/tcp");
     }
     
     @Test
-    public void validateDockerImageBookShop() {
-        ImageInspect imageInspect = getDockerImage(bookShopDockerImage);
-        Assert.assertEquals(imageInspect.getContainerConfig().getExposedPorts().size(), 1);
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9080/tcp"));
+    public void validateDockerImageBookShop() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(bookShopDockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9080/tcp");
     }
 
     @Test(enabled = false)
@@ -171,7 +171,7 @@ public class Sample16Test implements SampleTest {
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(bookReviewsDockerImage);
         KubernetesTestUtils.deleteDockerImage(bookDetailsDockerImage);

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample1Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample1Test.java
@@ -18,13 +18,13 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -34,10 +34,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample1Test implements SampleTest {
 
@@ -87,14 +88,14 @@ public class Sample1Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertEquals("9090/tcp", imageInspect.getContainerConfig().getExposedPorts().keySet().toArray()[0]);
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample2Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample2Test.java
@@ -18,7 +18,6 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
@@ -28,6 +27,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -42,7 +42,7 @@ import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample2Test implements SampleTest {
 
@@ -128,14 +128,14 @@ public class Sample2Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertEquals("9090/tcp", imageInspect.getContainerConfig().getExposedPorts().keySet().toArray()[0]);
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
@@ -17,7 +17,6 @@
  */
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -28,6 +27,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -42,7 +42,7 @@ import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample3Test implements SampleTest {
 
@@ -65,11 +65,11 @@ public class Sample3Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(2, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9099/tcp"));
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9096/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9099/tcp");
+        Assert.assertEquals(ports.get(1), "9096/tcp");
     }
 
     @Test
@@ -189,7 +189,7 @@ public class Sample3Test implements SampleTest {
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
@@ -67,9 +67,9 @@ public class Sample3Test implements SampleTest {
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
         List<String> ports = getExposedPorts(this.dockerImage);
-        Assert.assertEquals(ports.size(), 1);
-        Assert.assertEquals(ports.get(0), "9099/tcp");
-        Assert.assertEquals(ports.get(1), "9096/tcp");
+        Assert.assertEquals(ports.size(), 2);
+        Assert.assertEquals(ports.get(0), "9096/tcp");
+        Assert.assertEquals(ports.get(1), "9099/tcp");
     }
 
     @Test

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample5Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample5Test.java
@@ -58,7 +58,7 @@ public class Sample5Test implements SampleTest {
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
         List<String> ports = getExposedPorts(this.dockerImage);
-        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.size(), 2);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         Assert.assertEquals(ports.get(1), "9095/tcp");
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample5Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample5Test.java
@@ -18,11 +18,11 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -32,10 +32,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample5Test implements SampleTest {
     
@@ -55,11 +56,11 @@ public class Sample5Test implements SampleTest {
     }
     
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(2, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9095/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
+        Assert.assertEquals(ports.get(1), "9095/tcp");
     }
     
     @Test
@@ -77,7 +78,7 @@ public class Sample5Test implements SampleTest {
     }
     
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample7Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample7Test.java
@@ -18,7 +18,6 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -28,6 +27,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -42,7 +42,7 @@ import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample7Test implements SampleTest {
 
@@ -63,10 +63,10 @@ public class Sample7Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @Test
@@ -129,7 +129,7 @@ public class Sample7Test implements SampleTest {
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample9Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample9Test.java
@@ -18,13 +18,13 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
-import io.fabric8.docker.api.model.ImageInspect;
 import io.fabric8.kubernetes.api.KubernetesHelper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
@@ -34,10 +34,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
-import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDockerImage;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample9Test implements SampleTest {
 
@@ -92,14 +93,14 @@ public class Sample9Test implements SampleTest {
     }
 
     @Test
-    public void validateDockerImage() {
-        ImageInspect imageInspect = getDockerImage(dockerImage);
-        Assert.assertEquals(1, imageInspect.getContainerConfig().getExposedPorts().size());
-        Assert.assertTrue(imageInspect.getContainerConfig().getExposedPorts().keySet().contains("9090/tcp"));
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException {
+    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
         KubernetesUtils.deleteDirectory(targetPath);
         KubernetesTestUtils.deleteDockerImage(dockerImage);
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/SampleTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/SampleTest.java
@@ -19,6 +19,7 @@
 package org.ballerinax.kubernetes.test.samples;
 
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -31,5 +32,5 @@ public interface SampleTest {
     void compileSample() throws IOException, InterruptedException;
 
     @AfterClass
-    void cleanUp() throws KubernetesPluginException;
+    void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException;
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/DockerTestException.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/DockerTestException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.kubernetes.test.utils;
+
+/**
+ * Exception class for docker test cases.
+ */
+public class DockerTestException extends Exception {
+    public DockerTestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/KubernetesTestUtils.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/KubernetesTestUtils.java
@@ -18,26 +18,25 @@
 
 package org.ballerinax.kubernetes.test.utils;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.fabric8.docker.api.model.ImageInspect;
-import io.fabric8.docker.client.Config;
-import io.fabric8.docker.client.ConfigBuilder;
-import io.fabric8.docker.client.DockerClient;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ImageInfo;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.ballerinax.docker.generator.DockerGenConstants;
+import org.glassfish.jersey.internal.RuntimeDelegateImpl;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import static org.ballerinax.kubernetes.KubernetesConstants.UNIX_DEFAULT_DOCKER_HOST;
-import static org.ballerinax.kubernetes.KubernetesConstants.WINDOWS_DEFAULT_DOCKER_HOST;
+import java.util.Objects;
+import javax.ws.rs.ext.RuntimeDelegate;
 
 /**
  * Kubernetes test utils.
@@ -60,36 +59,68 @@ public class KubernetesTestUtils {
             br.lines().forEach(log::info);
         }
     }
-
+    
     /**
      * Return a ImageInspect object for a given Docker Image name
      *
      * @param imageName Docker image Name
      * @return ImageInspect object
      */
-    public static ImageInspect getDockerImage(String imageName) {
-        DockerClient client = getDockerClient();
-        return client.image().withName(imageName).inspect();
+    public static ImageInfo getDockerImage(String imageName) throws DockerTestException, InterruptedException {
+        try {
+            DockerClient client = getDockerClient();
+            return client.inspectImage(imageName);
+        } catch (DockerException e) {
+            throw new DockerTestException(e);
+        }
     }
-
+    
+    /**
+     * Get the list of exposed ports of the docker image.
+     *
+     * @param imageName The docker image name.
+     * @return Exposed ports.
+     * @throws DockerTestException      If issue occurs inspecting docker image
+     * @throws InterruptedException If issue occurs inspecting docker image
+     */
+    public static List<String> getExposedPorts(String imageName) throws DockerTestException, InterruptedException {
+        ImageInfo dockerImage = getDockerImage(imageName);
+        return Objects.requireNonNull(dockerImage.config().exposedPorts()).asList();
+    }
+    
+    /**
+     * Get the list of commands of the docker image.
+     *
+     * @param imageName The docker image name.
+     * @return The list of commands.
+     * @throws DockerTestException      If issue occurs inspecting docker image
+     * @throws InterruptedException If issue occurs inspecting docker image
+     */
+    public static List<String> getCommand(String imageName) throws DockerTestException, InterruptedException {
+        ImageInfo dockerImage = getDockerImage(imageName);
+        return dockerImage.config().cmd();
+    }
+    
     /**
      * Delete a given Docker image and prune
      *
      * @param imageName Docker image Name
      */
-    public static void deleteDockerImage(String imageName) {
-        DockerClient client = getDockerClient();
-        client.image().withName(imageName).delete().andPrune();
+    public static void deleteDockerImage(String imageName) throws DockerTestException, InterruptedException {
+        try {
+            DockerClient client = getDockerClient();
+            client.removeImage(imageName, true, false);
+        } catch (DockerException e) {
+            throw new DockerTestException(e);
+        }
     }
-
+    
     private static DockerClient getDockerClient() {
-        disableFailOnUnknownProperties();
+        RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
         String operatingSystem = System.getProperty("os.name").toLowerCase(Locale.getDefault());
-        String dockerHost = operatingSystem.contains("win") ? WINDOWS_DEFAULT_DOCKER_HOST : UNIX_DEFAULT_DOCKER_HOST;
-        Config dockerClientConfig = new ConfigBuilder()
-                .withDockerUrl(dockerHost)
-                .build();
-        return new io.fabric8.docker.client.DefaultDockerClient(dockerClientConfig);
+        String dockerHost = operatingSystem.contains("win") ? DockerGenConstants.WINDOWS_DEFAULT_DOCKER_HOST :
+                            DockerGenConstants.UNIX_DEFAULT_DOCKER_HOST;
+        return DefaultDockerClient.builder().uri(dockerHost).build();
     }
 
     /**
@@ -151,20 +182,6 @@ public class KubernetesTestUtils {
         logOutput(process.getInputStream());
         logOutput(process.getErrorStream());
         return exitCode;
-    }
-
-    // Disable fail on unknown properties using reflection to avoid docker client issue.
-    // (https://github.com/fabric8io/docker-client/issues/106).
-    private static void disableFailOnUnknownProperties() {
-        try {
-            final Field jsonMapperField = Config.class.getDeclaredField("JSON_MAPPER");
-            assert jsonMapperField != null;
-            jsonMapperField.setAccessible(true);
-            final ObjectMapper objectMapper = (ObjectMapper) jsonMapperField.get(null);
-            assert objectMapper != null;
-            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        } catch (NoSuchFieldException | IllegalAccessException ignored) {
-        }
     }
     
     private static synchronized void addJavaAgents(Map<String, String> envProperties) {

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/KubernetesTestUtils.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/KubernetesTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.ballerinax.kubernetes.test.utils;
 
+import com.mchange.io.FileUtils;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerException;
@@ -32,6 +33,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -146,6 +150,12 @@ public class KubernetesTestUtils {
         log.info(EXIT_CODE + exitCode);
         logOutput(process.getInputStream());
         logOutput(process.getErrorStream());
+    
+        // log ballerina-internal.log content
+        Path ballerinaInternalLog = Paths.get(sourceDirectory, "ballerina-internal.log");
+        if (exitCode == 1 && Files.exists(ballerinaInternalLog)) {
+            log.info(FileUtils.getContentsAsString(ballerinaInternalLog.toFile()));
+        }
         return exitCode;
     }
 

--- a/kubernetes-extension/pom.xml
+++ b/kubernetes-extension/pom.xml
@@ -239,49 +239,90 @@
                             <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <includes>
-                                    <include>io.fabric8:*</include>
-                                    <include>commons-io:commons-io</include>
-                                    <include>commons-io.wso2:commons-io</include>
-                                    <include>commons-codec:commons-codec</include>
-                                    <include>javax.validation:validation-api</include>
-                                    <include>javax.ws.rs:javax.ws.rs-api</include>
-                                    <include>com.squareup.okhttp3:okhttp</include>
-                                    <include>com.squareup.okhttp3:logging-interceptor</include>
-                                    <include>com.squareup.okio:okio</include>
-                                    <include>org.apache.commons:commons-compress</include>
-                                    <include>com.github.jnr:jnr-unixsocket</include>
-                                    <include>com.github.jnr:jnr-ffi</include>
+                                    <incldue>com.spotify:docker-client</incldue>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-guava</include>
+                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
+                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
                                     <include>com.github.jnr:jffi</include>
                                     <include>com.github.jnr:jnr-constants</include>
                                     <include>com.github.jnr:jnr-enxio</include>
+                                    <include>com.github.jnr:jnr-ffi</include>
                                     <include>com.github.jnr:jnr-posix</include>
-                                    <include>org.ow2.asm:asm</include>
-                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
-                                    <include>com.fasterxml.jackson.core:jackson-core</include>
-                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.github.jnr:jnr-unixsocket</include>
+                                    <include>commons-codec:commons-codec</include>
+                                    <include>commons-io:commons-io</include>
+                                    <include>io.fabric8:*</include>
+                                    <inculde>javax.annotation:javax.annotation-api</inculde>
+                                    <include>javax.validation:validation-api</include>
+                                    <include>javax.ws.rs:javax.ws.rs-api</include>
+                                    <include>org.apache.commons:commons-compress</include>
+                                    <include>org.apache.httpcomponents:httpclient</include>
+                                    <include>org.apache.httpcomponents:httpcore</include>
                                     <include>org.ballerinax.docker:docker-generator</include>
+                                    <include>org.glassfish.hk2.external:javax.inject</include>
+                                    <include>org.glassfish.hk2:hk2-api</include>
+                                    <include>org.glassfish.hk2:hk2-locator</include>
+                                    <include>org.glassfish.hk2:hk2-utils</include>
+                                    <include>org.glassfish.jersey.bundles.repackaged:jersey-guava</include>
+                                    <include>org.glassfish.jersey.connectors:jersey-apache-connector</include>
+                                    <include>org.glassfish.jersey.core:jersey-client</include>
+                                    <include>org.glassfish.jersey.core:jersey-common</include>
+                                    <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
+                                    <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
+                                    <include>org.ow2.asm:asm</include>
                                 </includes>
                                 <excludes>
-                                    <exclude>org.slf4j:slf4j-api</exclude>
-                                    <exclude>org.slf4j:slf4j-jdk14</exclude>
-                                    <exclude>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</exclude>
-                                    <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
                                     <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
                                     <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+                                    <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                                    <exclude>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</exclude>
                                     <exclude>commons-lang:commons-lang</exclude>
-                                    <exclude>org.yaml:snakeyaml</exclude>
-                                    <exclude>org.ballerinalang:ballerina-lang</exclude>
-                                    <exclude>org.ballerinalang:ballerina-launcher</exclude>
                                     <exclude>org.ballerinalang:ballerina-builtin</exclude>
                                     <exclude>org.ballerinalang:ballerina-core</exclude>
-                                    <exclude>org.ballerinalang:ballerina-mime</exclude>
-                                    <exclude>org.ballerinalang:ballerina-logging</exclude>
                                     <exclude>org.ballerinalang:ballerina-http</exclude>
-                                    <exclude>org.testng:testng</exclude>
+                                    <exclude>org.ballerinalang:ballerina-lang</exclude>
+                                    <exclude>org.ballerinalang:ballerina-launcher</exclude>
+                                    <exclude>org.ballerinalang:ballerina-logging</exclude>
+                                    <exclude>org.ballerinalang:ballerina-mime</exclude>
                                     <exclude>org.bsc.maven:maven-processor-plugin</exclude>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                    <exclude>org.testng:testng</exclude>
+                                    <exclude>org.wso2.msf4j:jaxrs-delegates</exclude>
+                                    <exclude>org.yaml:snakeyaml</exclude>
                                 </excludes>
                             </artifactSet>
                             <filters>
+                                <filter>
+                                    <artifact>org.glassfish.jersey.core:jersey-client</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.glassfish.jersey.core:jersey-common</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.glassfish.hk2:hk2-locator</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.glassfish.hk2:hk2-utils</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.glassfish.hk2:hk2-api</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
                                 <filter>
                                     <artifact>com.github.jnr:jffi</artifact>
                                     <includes>
@@ -314,6 +355,12 @@
                                 </filter>
                                 <filter>
                                     <artifact>com.github.jnr:jnr-posix</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.spotify:docker-client</artifact>
                                     <includes>
                                         <include>**</include>
                                     </includes>

--- a/kubernetes-extension/pom.xml
+++ b/kubernetes-extension/pom.xml
@@ -50,7 +50,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.fabric8</groupId>
+            <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
         </dependency>
         <dependency>
@@ -244,6 +244,7 @@
                                     <include>commons-io.wso2:commons-io</include>
                                     <include>commons-codec:commons-codec</include>
                                     <include>javax.validation:validation-api</include>
+                                    <include>javax.ws.rs:javax.ws.rs-api</include>
                                     <include>com.squareup.okhttp3:okhttp</include>
                                     <include>com.squareup.okhttp3:logging-interceptor</include>
                                     <include>com.squareup.okio:okio</include>

--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>io.fabric8</groupId>
+                <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>
-                <version>${docker.client.version}</version>
+                <version>${spotify.docker.client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.ballerinalang</groupId>
@@ -264,7 +264,6 @@
         <ballerina.source.directory>${project.build.directory}/../src/main/ballerina</ballerina.source.directory>
         <com.fasterxml.jackson.core.annotations.version>2.9.1</com.fasterxml.jackson.core.annotations.version>
         <com.fasterxml.jackson.dataformat.yaml.version>2.9.1</com.fasterxml.jackson.dataformat.yaml.version>
-        <docker.client.version>1.3.1</docker.client.version>
         <docker.generator.version>0.990.3-SNAPSHOT</docker.generator.version>
         <fabric8.kubernetes.api.version>3.0.11</fabric8.kubernetes.api.version>
         <fabric8.kubernetes.client.version>3.1.10</fabric8.kubernetes.client.version>
@@ -274,6 +273,7 @@
         <mvn.shade.plugin.version>3.1.1</mvn.shade.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <spotify.docker.client.version>8.14.5</spotify.docker.client.version>
         <testng.version>6.14.3</testng.version>
     </properties>
 


### PR DESCRIPTION
## Purpose
> Fabric8 docker client is no longer maintained. Hence moving to a newer client.

## Goals
> Use maintained libraries.
