### PR TITLE
Add missing dependency needed for jenkins

### DIFF
--- a/kubernetes-extension-test/pom.xml
+++ b/kubernetes-extension-test/pom.xml
@@ -60,6 +60,11 @@
             <classifier>ballerina-binary-repo</classifier>
         </dependency>
         <dependency>
+            <groupId>org.ballerinax.docker</groupId>
+            <artifactId>docker-generator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Purpose
> Jenkins build is failing due to missing dependency. 
```
[ERROR] /home/jenkins/workspace/ballerinax/kubernetes/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/utils/KubernetesTestUtils.java:[28,39] cannot find symbol
[ERROR] symbol:   class DockerGenConstants
[ERROR] location: package org.ballerinax.docker.generator
```

This PR should fix this issue.

## Goals
> Fix jenkins build.

## Approach
> Add missing dependency.