### PR TITLE
Fix error wording when @kubernetes:Service is used on an non anonymous listener of service.

### DIFF
--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
@@ -54,7 +54,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
             // If not anonymous endpoint throw error.
             if (attachedExpr instanceof BLangSimpleVarRef) {
                 throw new KubernetesPluginException("Adding @kubernetes:Service{} annotation to a service is only " +
-                                                    "supported when the has an anonymous listener");
+                                                    "supported when the service has an anonymous listener");
             }
             
         }


### PR DESCRIPTION
## Purpose
> Fix error wording when @kubernetes:Service is used on an non anonymous
listener of service. Fixes https://github.com/ballerinax/kubernetes/issues/268.
