### PR TITLE
Modify samples to have singleYAML:false by default

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/DeploymentTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -39,10 +40,9 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDocker
  * Test creating kubernetes deployment artifacts.
  */
 public class DeploymentTest {
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("deployment")
-            .toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
-    private final String dockerImage = "pizza-shop:latest";
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "deployment");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "pizza-shop:latest";
     
     /**
      * Build bal file with deployment having annotations.
@@ -54,14 +54,14 @@ public class DeploymentTest {
     @Test
     public void annotationsTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "dep_annotations.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "dep_annotations.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("dep_annotations_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("dep_annotations_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertEquals(deployment.getMetadata().getAnnotations().size(), 2,
@@ -71,8 +71,8 @@ public class DeploymentTest {
         Assert.assertEquals(deployment.getMetadata().getAnnotations().get("anno2"), "anno2Val",
                 "Invalid annotation found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -85,14 +85,14 @@ public class DeploymentTest {
     @Test
     public void podAnnotationsTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "pod_annotations.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "pod_annotations.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("pod_annotations_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("pod_annotations_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertEquals(deployment.getSpec().getTemplate().getMetadata().getAnnotations().size(), 2,
@@ -102,15 +102,15 @@ public class DeploymentTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getMetadata().getAnnotations().get("anno2"), "anno2Val",
                 "Invalid annotation found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
@@ -118,7 +118,7 @@ public class DeploymentTest {
      * Validate contents of the Dockerfile.
      */
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        ImageInfo imageInspect = getDockerImage(dockerImage);
+        ImageInfo imageInspect = getDockerImage(DOCKER_IMAGE);
         Assert.assertNotEquals(imageInspect, null, "Image not found");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/EnvVarTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/EnvVarTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
@@ -42,10 +43,9 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
  * Test setting environment variables for deployments.
  */
 public class EnvVarTest {
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("env-vars")
-            .toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
-    private final String dockerImage = "pizza-shop:latest";
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "env-vars");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "pizza-shop:latest";
     
     /**
      * Build bal file with deployment having name value environment variables.
@@ -56,14 +56,14 @@ public class EnvVarTest {
     @Test
     public void nameValueTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "name_value.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "name_value.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("name_value_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("name_value_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -73,8 +73,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(1).getName(), "city", "Invalid environment variable name found.");
         Assert.assertEquals(envVars.get(1).getValue(), "COLOMBO", "Invalid environment variable value found.");
     
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -90,7 +90,7 @@ public class EnvVarTest {
         Map<String, String> bRunEnvVar = new HashMap<>();
         bRunEnvVar.put("DATABASE_USERNAME", "root");
         bRunEnvVar.put("DATABASE_PASSWORD", "rootpwd");
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "build_name_value.bal", bRunEnvVar),
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "build_name_value.bal", bRunEnvVar),
                 0);
         
         // Check if docker image exists and correct
@@ -98,7 +98,7 @@ public class EnvVarTest {
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("build_name_value_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("build_name_value_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -112,8 +112,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(3).getName(), "DATABASE_PASSWORD", "Invalid environment variable name found.");
         Assert.assertEquals(envVars.get(3).getValue(), "rootpwd", "Invalid environment variable value found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -125,14 +125,14 @@ public class EnvVarTest {
     @Test
     public void fieldRefTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "field_ref_value.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "field_ref_value.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("field_ref_value_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("field_ref_value_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -146,8 +146,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(1).getValueFrom().getFieldRef().getFieldPath(), "metadata.name",
                 "Invalid environment variable value found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -159,14 +159,14 @@ public class EnvVarTest {
     @Test
     public void secretKeyRefTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "secret_key_ref.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "secret_key_ref.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("secret_key_ref_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("secret_key_ref_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -184,8 +184,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(1).getValueFrom().getSecretKeyRef().getKey(), "password",
                 "Invalid environment variable value found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -197,14 +197,14 @@ public class EnvVarTest {
     @Test
     public void resourceFieldRefTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "resource_field_ref_value.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "resource_field_ref_value.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("resource_field_ref_value_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("resource_field_ref_value_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -220,8 +220,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(1).getValueFrom().getResourceFieldRef().getResource(), "limits.cpu",
                 "Invalid environment variable value found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -233,14 +233,14 @@ public class EnvVarTest {
     @Test
     public void configMapKeyRefTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "config_map_key_ref.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "config_map_key_ref.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("config_map_key_ref_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("config_map_key_ref_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -258,8 +258,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(1).getValueFrom().getConfigMapKeyRef().getKey(), "log_level",
                 "Invalid environment variable value found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -271,14 +271,14 @@ public class EnvVarTest {
     @Test
     public void combinedTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "combination.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "combination.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("combination_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("combination_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         List<EnvVar> envVars = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -309,8 +309,8 @@ public class EnvVarTest {
         Assert.assertEquals(envVars.get(4).getValueFrom().getSecretKeyRef().getKey(), "password",
                 "Invalid environment variable value found.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -321,15 +321,15 @@ public class EnvVarTest {
      */
     @Test
     public void invalidTest() throws IOException, InterruptedException, KubernetesPluginException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "invalid.bal"), 1);
-        KubernetesUtils.deleteDirectory(targetPath);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "invalid.bal"), 1);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
     }
     
     /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
@@ -337,7 +337,7 @@ public class EnvVarTest {
      * Validate contents of the Dockerfile.
      */
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9099/tcp");
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioGatewayTest.java
@@ -30,6 +30,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -45,10 +46,9 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
  */
 public class IstioGatewayTest {
     
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("istio")
-            .resolve("gateway").toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
-    private final String dockerImage = "pizza-shop:latest";
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "istio", "gateway");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "pizza-shop:latest";
     
     /**
      * Build bal file with istio gateway annotations.
@@ -60,14 +60,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void allFieldsTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "all_fields.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "all_fields.bal"), 0);
 
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
 
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("all_fields_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("all_fields_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -105,8 +105,8 @@ public class IstioGatewayTest {
         Map<String, Object> tls = (Map<String, Object>) server.get("tls");
         Assert.assertEquals(tls.get("httpsRedirect"), true, "Invalid tls httpsRedirect value");
 
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -117,7 +117,7 @@ public class IstioGatewayTest {
      */
     @Test(enabled = false, groups = {"istio"})
     public void invalidPortTest() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "invalid_port.bal"), 1);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "invalid_port.bal"), 1);
     }
     
     /**
@@ -130,14 +130,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void multipleServersTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "multiple_servers.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "multiple_servers.bal"), 0);
 
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
 
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("multiple_servers_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("multiple_servers_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -179,8 +179,8 @@ public class IstioGatewayTest {
         Map<String, Object> tls2 = (Map<String, Object>) server2.get("tls");
         Assert.assertEquals(tls2.get("httpsRedirect"), false, "Invalid tls httpsRedirect value");
 
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -192,14 +192,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void noSelectorTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "no_selector.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_selector.bal"), 0);
     
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
     
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("no_selector_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("no_selector_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         
@@ -210,8 +210,8 @@ public class IstioGatewayTest {
         Assert.assertEquals(selector.get(KubernetesConstants.ISTIO_GATEWAY_SELECTOR), "ingressgateway",
                 "Invalid selector.");
     
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -224,14 +224,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void noTLSHttpRedirect() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "no_tls_https_redirect.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_tls_https_redirect.bal"), 0);
 
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
 
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("no_tls_https_redirect_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("no_tls_https_redirect_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -259,8 +259,8 @@ public class IstioGatewayTest {
 
         Assert.assertNull(server.get("tls"), "tls options should not be available");
 
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -273,14 +273,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void tlsMutualTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_mutual.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "tls_mutual.bal"), 0);
 
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
 
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("tls_mutual_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("tls_mutual_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -315,8 +315,8 @@ public class IstioGatewayTest {
         Assert.assertEquals(tls1.get("caCertificates"), "/etc/istio/ingressgateway-ca-certs/ca-chain.cert.pem",
                 "Invalid tls caCertificates value");
 
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -327,7 +327,7 @@ public class IstioGatewayTest {
      */
     @Test(enabled = false, groups = {"istio"})
     public void invalidTlsMutualTest() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_mutual_invalid.bal"), 1);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "tls_mutual_invalid.bal"), 1);
     }
     
     /**
@@ -340,14 +340,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void tlsSimpleTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_simple.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "tls_simple.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("tls_simple_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("tls_simple_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -380,8 +380,8 @@ public class IstioGatewayTest {
         Assert.assertEquals(tls1.get("privateKey"), "/etc/istio/ingressgateway-certs/tls.key",
                 "Invalid tls privateKey value");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -394,14 +394,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void emptyAnnoForEndpointTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "empty_annotation_ep.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "empty_annotation_ep.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("empty_annotation_ep_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("empty_annotation_ep_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -425,8 +425,8 @@ public class IstioGatewayTest {
         List<String> hosts = (List<String>) server.get("hosts");
         Assert.assertTrue(hosts.contains("*"), "* host not included");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -439,14 +439,14 @@ public class IstioGatewayTest {
     @Test(groups = {"istio"})
     public void emptyAnnotationForSvcTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "empty_annotation_svc.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "empty_annotation_svc.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate gateway yaml
-        File gatewayFile = Paths.get(targetPath).resolve("empty_annotation_svc_istio_gateway.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("empty_annotation_svc_istio_gateway.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -470,8 +470,8 @@ public class IstioGatewayTest {
         List<String> hosts = (List<String>) server.get("hosts");
         Assert.assertTrue(hosts.contains("*"), "* host not included");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -482,14 +482,14 @@ public class IstioGatewayTest {
      */
     @Test(enabled = false, groups = {"istio"})
     public void invalidTlsSimpleTest() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_simple_invalid.bal"), 1);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "tls_simple_invalid.bal"), 1);
     }
     
     /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
@@ -497,7 +497,7 @@ public class IstioGatewayTest {
      * Validate contents of the Dockerfile.
      */
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioVirtualServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/IstioVirtualServiceTest.java
@@ -29,6 +29,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -44,10 +45,9 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
  */
 public class IstioVirtualServiceTest {
     
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("istio")
-            .resolve("virtual-service").toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
-    private final String dockerImage = "pizza-shop:latest";
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "istio", "virtual-service");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "pizza-shop:latest";
     
     /**
      * Build bal file with istio virtual service annotation with http route.
@@ -59,14 +59,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void httpRouteTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_route.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "http_route.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("http_route_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("http_route_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -111,8 +111,8 @@ public class IstioVirtualServiceTest {
                 "Invalid route destination host");
         Assert.assertEquals(route2.get(0).get("destination").get("subset"), "v1", "Invalid route destination subset");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -125,14 +125,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void httpMatchRequestTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_match_request.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "http_match_request.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("http_match_request_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("http_match_request_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -161,8 +161,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(route.get(0).get("destination").get("host"), "ratings.prod.svc.cluster.local",
                 "Invalid route destination host");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -175,14 +175,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void destinationWeightTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "destination_weight.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "destination_weight.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("destination_weight_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("destination_weight_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -212,8 +212,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(destination2.get("subset"), "v1", "Invalid route destination subset");
         Assert.assertEquals(route.get(1).get("weight"), 75, "Invalid route weight");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -226,14 +226,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void destinationTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "destination.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "destination.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("destination_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("destination_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -257,8 +257,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(destination1.get("host"), "reviews.prod.svc.cluster.local",
                 "Invalid route destination host");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -271,14 +271,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void httpRedirectTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_redirect.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "http_redirect.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("http_redirect_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("http_redirect_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -304,8 +304,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(redirect.get("authority"), "newratings.default.svc.cluster.local",
                 "Invalid redirect authority");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -318,14 +318,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void httpRetryTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_retry.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "http_retry.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("http_retry_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("http_retry_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -352,8 +352,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(retries.get("attempts"), 3, "Invalid number of retry attempts");
         Assert.assertEquals(retries.get("perTryTimeout"), "2s", "Invalid number of retry timeout try");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -366,14 +366,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void httpFaultInjectionTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "http_fault_injection.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "http_fault_injection.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("http_fault_injection_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("http_fault_injection_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -400,8 +400,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(fault.get("abort").get("percent"), 10, "Invalid fault abort percent");
         Assert.assertEquals(fault.get("abort").get("httpStatus"), 400, "Invalid fault abort http status code");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -414,14 +414,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void corsPolicyTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "cors_policy.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "cors_policy.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("cors_policy_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("cors_policy_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -454,8 +454,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(((List<String>) corsPolicy.get("allowHeaders")).get(0), "X-Foo-Bar",
                 "Invalid cors allowHeaders");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -468,14 +468,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void tlsRouteTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tls_route.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "tls_route.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("tls_route_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("tls_route_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -514,8 +514,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(route2.get(0).get("destination").get("host"), "reviews.prod.svc.cluster.local",
                 "Invalid route destination host");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -528,14 +528,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void tcpRouteTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "tcp_route.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "tcp_route.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("tcp_route_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("tcp_route_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -563,8 +563,8 @@ public class IstioVirtualServiceTest {
         Assert.assertEquals(((Map<String, Object>) destination.get("port")).get("number"), 5555,
                 "Invalid destination port");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -577,14 +577,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void emptyAnnotationTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "empty_annotation.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "empty_annotation.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File vsFile = Paths.get(targetPath).resolve("empty_annotation_istio_virtual_service.yaml").toFile();
+        File vsFile = TARGET_PATH.resolve("empty_annotation_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(vsFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -610,8 +610,8 @@ public class IstioVirtualServiceTest {
         Map<String, Object> port = (Map<String, Object>) destination.get("port");
         Assert.assertEquals(port.get("number"), 9090, "Invalid port found");
     
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -624,14 +624,14 @@ public class IstioVirtualServiceTest {
     @Test(groups = {"istio"})
     public void useServiceAnnotationPortTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "svc_port.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "svc_port.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate virtual service yaml
-        File gatewayFile = Paths.get(targetPath).resolve("svc_port_istio_virtual_service.yaml").toFile();
+        File gatewayFile = TARGET_PATH.resolve("svc_port_istio_virtual_service.yaml").toFile();
         Assert.assertTrue(gatewayFile.exists());
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> gateway = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(gatewayFile));
@@ -657,15 +657,15 @@ public class IstioVirtualServiceTest {
         Map<String, Object> port = (Map<String, Object>) destination.get("port");
         Assert.assertEquals(port.get("number"), 8080, "Invalid port found");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
@@ -673,7 +673,7 @@ public class IstioVirtualServiceTest {
      * Validate contents of the Dockerfile.
      */
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/LivenessProbeTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/LivenessProbeTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -39,10 +40,9 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDocker
  * Test cases for deployment liveness probes.
  */
 public class LivenessProbeTest {
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("deployment")
-            .resolve("liveness-probe").toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
-    private final String dockerImage = "pizza-shop:latest";
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "deployment", "liveness-probe");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "pizza-shop:latest";
     
     /**
      * Build bal file with deployment having liveness disabled.
@@ -54,14 +54,14 @@ public class LivenessProbeTest {
     @Test
     public void disabledTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "disabled.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "disabled.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("disabled_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("disabled_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -70,8 +70,8 @@ public class LivenessProbeTest {
         Assert.assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().size() > 0);
         Assert.assertNull(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe());
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -83,14 +83,14 @@ public class LivenessProbeTest {
      */
     @Test
     public void enabledTest() throws IOException, InterruptedException, KubernetesPluginException, DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "enabled.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "enabled.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("enabled_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("enabled_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -106,8 +106,8 @@ public class LivenessProbeTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe()
                 .getTcpSocket().getPort().getIntVal().intValue(), 9090, "TCP port in liveness probe is missing.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -120,14 +120,14 @@ public class LivenessProbeTest {
     @Test
     public void enabledWithEmptyRecordTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "enabled_with_record.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "enabled_with_record.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("enabled_with_record_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("enabled_with_record_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -143,8 +143,8 @@ public class LivenessProbeTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe()
                 .getTcpSocket().getPort().getIntVal().intValue(), 9090, "TCP port in liveness probe is missing.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -157,14 +157,14 @@ public class LivenessProbeTest {
     @Test
     public void configuredTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "configured.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "configured.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("configured_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("configured_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -180,15 +180,15 @@ public class LivenessProbeTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe()
                 .getTcpSocket().getPort().getIntVal().intValue(), 8080, "TCP port in liveness probe is missing.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
@@ -196,7 +196,7 @@ public class LivenessProbeTest {
      * Validate contents of the Dockerfile.
      */
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        ImageInfo imageInspect = getDockerImage(dockerImage);
+        ImageInfo imageInspect = getDockerImage(DOCKER_IMAGE);
         Assert.assertNotEquals(imageInspect, null, "Image not found");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/OpenShiftBuildConfigTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/OpenShiftBuildConfigTest.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.ImageStream;
-import org.apache.commons.io.FileUtils;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
@@ -43,17 +42,16 @@ import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
  * Test cases for @kubernetes:OpenShiftBuildConfig{} annotation generated artifacts.
  */
 public class OpenShiftBuildConfigTest {
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("openshift")
-            .resolve("build-config").toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "openshift", "build-config");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
     
     /**
      * Test case openshift build config annotation with default values.
      */
     @Test(groups = {"openshift"})
     public void simpleBuildConfigTest() throws IOException, InterruptedException, KubernetesPluginException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "simple_bc.bal"), 0);
-        File yamlFile = new File(targetPath + File.separator + "simple_bc.yaml");
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "simple_bc.bal"), 0);
+        File yamlFile = new File(TARGET_PATH + File.separator + "simple_bc.yaml");
         Assert.assertTrue(yamlFile.exists());
         KubernetesClient client = new DefaultKubernetesClient();
         List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
@@ -107,12 +105,12 @@ public class OpenShiftBuildConfigTest {
                     Assert.assertNull(is.getSpec());
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
     
-        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
     }
     
     /**
@@ -120,8 +118,8 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void withNoNamespaceTest() throws IOException, InterruptedException {
-        KubernetesTestUtils.compileBallerinaFile(balDirectory, "no_namespace.bal");
-        File yamlFile = new File(targetPath + File.separator + "no_namespace.yaml");
+        KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_namespace.bal");
+        File yamlFile = new File(TARGET_PATH + File.separator + "no_namespace.yaml");
         Assert.assertFalse(yamlFile.exists());
     }
     
@@ -130,8 +128,8 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void withNoRegistryTest() throws IOException, InterruptedException {
-        KubernetesTestUtils.compileBallerinaFile(balDirectory, "no_registry.bal");
-        File yamlFile = new File(targetPath + File.separator + "no_registry.yaml");
+        KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_registry.bal");
+        File yamlFile = new File(TARGET_PATH + File.separator + "no_registry.yaml");
         Assert.assertFalse(yamlFile.exists());
     }
     
@@ -140,7 +138,7 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void multipleBuildAnnotations() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "multiple_build_annotations.bal"),
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "multiple_build_annotations.bal"),
                 0);
     }
     
@@ -149,8 +147,8 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void mainFunctionTest() throws IOException, InterruptedException, KubernetesPluginException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "main_function.bal"), 0);
-        File yamlFile = new File(targetPath + File.separator + "main_function.yaml");
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "main_function.bal"), 0);
+        File yamlFile = new File(TARGET_PATH + File.separator + "main_function.yaml");
         Assert.assertTrue(yamlFile.exists());
         KubernetesClient client = new DefaultKubernetesClient();
         List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
@@ -204,12 +202,12 @@ public class OpenShiftBuildConfigTest {
                     Assert.assertNull(is.getSpec());
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
         
-        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
     }
     
     /**
@@ -217,8 +215,8 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void noCacheAndForcePullTest() throws IOException, InterruptedException, KubernetesPluginException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "cache_and_force_pull.bal"), 0);
-        File yamlFile = new File(targetPath + File.separator + "cache_and_force_pull.yaml");
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "cache_and_force_pull.bal"), 0);
+        File yamlFile = new File(TARGET_PATH + File.separator + "cache_and_force_pull.yaml");
         Assert.assertTrue(yamlFile.exists());
         KubernetesClient client = new DefaultKubernetesClient();
         List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
@@ -272,12 +270,12 @@ public class OpenShiftBuildConfigTest {
                     Assert.assertNull(is.getSpec());
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
         
-        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
     }
     
     /**
@@ -285,8 +283,8 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void serviceAnnotationTest() throws IOException, InterruptedException, KubernetesPluginException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "annotation_on_service.bal"), 0);
-        File yamlFile = new File(targetPath + File.separator + "annotation_on_service.yaml");
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "annotation_on_service.bal"), 0);
+        File yamlFile = new File(TARGET_PATH + File.separator + "annotation_on_service.yaml");
         Assert.assertTrue(yamlFile.exists());
         KubernetesClient client = new DefaultKubernetesClient();
         List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
@@ -340,12 +338,12 @@ public class OpenShiftBuildConfigTest {
                     Assert.assertNull(is.getSpec());
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
         
-        KubernetesUtils.deleteDirectory(targetPath);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
     }
     
     /**
@@ -353,14 +351,11 @@ public class OpenShiftBuildConfigTest {
      */
     @Test(groups = {"openshift"})
     public void buildProject() throws IOException, InterruptedException, KubernetesPluginException {
-        Path projectPath = Paths.get(balDirectory).resolve("print-project");
+        Path projectPath = BAL_DIRECTORY.resolve("print-project");
         Path targetPath = projectPath.resolve("target");
-        Path projectTarget = targetPath.resolve("kubernetes").resolve("printer");
-        
-        FileUtils.deleteQuietly(targetPath.toFile());
-    
+        Path moduleArtifacts = targetPath.resolve(KUBERNETES).resolve("printer");
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaProject(projectPath.toAbsolutePath()), 0);
-        File yamlFile = targetPath.resolve(projectTarget).resolve("printer.yaml").toAbsolutePath().toFile();
+        File yamlFile = moduleArtifacts.resolve("printer.yaml").toAbsolutePath().toFile();
         Assert.assertTrue(yamlFile.exists());
         KubernetesClient client = new DefaultKubernetesClient();
         List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
@@ -414,7 +409,7 @@ public class OpenShiftBuildConfigTest {
                     Assert.assertNull(is.getSpec());
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/OpenShiftRouteTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/OpenShiftRouteTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -40,9 +41,8 @@ import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
  * Test cases for @kubernetes:OpenShiftRoute{} annotation generated artifacts.
  */
 public class OpenShiftRouteTest {
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("openshift")
-            .resolve("route").toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
+    private final Path balDirectory = Paths.get("src", "test", "resources", "openshift", "route");
+    private final Path targetPath = balDirectory.resolve(KUBERNETES);
     
     /**
      * Test case openshift route with host domain.
@@ -81,7 +81,7 @@ public class OpenShiftRouteTest {
                     
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
@@ -124,7 +124,7 @@ public class OpenShiftRouteTest {
                     
                     break;
                 default:
-                    Assert.fail("Unknown k8s resource found: " + data.getKind());
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ReadinessProbeTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ReadinessProbeTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -39,10 +40,9 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDocker
  * Test cases for deployment readiness probes.
  */
 public class ReadinessProbeTest {
-    private final String balDirectory = Paths.get("src").resolve("test").resolve("resources").resolve("deployment")
-            .resolve("readiness-probe").toAbsolutePath().toString();
-    private final String targetPath = Paths.get(balDirectory).resolve(KUBERNETES).toString();
-    private final String dockerImage = "pizza-shop:latest";
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "deployment", "readiness-probe");
+    private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "pizza-shop:latest";
     
     /**
      * Build bal file with deployment having readiness disabled.
@@ -54,14 +54,14 @@ public class ReadinessProbeTest {
     @Test
     public void disabledTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "disabled.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "disabled.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("disabled_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("disabled_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -70,8 +70,8 @@ public class ReadinessProbeTest {
         Assert.assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().size() > 0);
         Assert.assertNull(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe());
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -83,14 +83,14 @@ public class ReadinessProbeTest {
      */
     @Test
     public void enabledTest() throws IOException, InterruptedException, KubernetesPluginException, DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "enabled.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "enabled.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("enabled_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("enabled_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -106,8 +106,8 @@ public class ReadinessProbeTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe()
                 .getTcpSocket().getPort().getIntVal().intValue(), 9090, "TCP port in readiness probe is missing.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -120,14 +120,14 @@ public class ReadinessProbeTest {
     @Test
     public void enabledWithEmptyRecordTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "enabled_with_record.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "enabled_with_record.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("enabled_with_record_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("enabled_with_record_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -143,8 +143,8 @@ public class ReadinessProbeTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe()
                 .getTcpSocket().getPort().getIntVal().intValue(), 9090, "TCP port in readiness probe is missing.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -157,14 +157,14 @@ public class ReadinessProbeTest {
     @Test
     public void configuredTest() throws IOException, InterruptedException, KubernetesPluginException,
             DockerTestException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(balDirectory, "configured.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "configured.bal"), 0);
         
         // Check if docker image exists and correct
         validateDockerfile();
         validateDockerImage();
         
         // Validate deployment yaml
-        File deploymentYAML = Paths.get(targetPath).resolve("configured_deployment.yaml").toFile();
+        File deploymentYAML = TARGET_PATH.resolve("configured_deployment.yaml").toFile();
         Assert.assertTrue(deploymentYAML.exists());
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         Assert.assertNotNull(deployment.getSpec());
@@ -180,15 +180,15 @@ public class ReadinessProbeTest {
         Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe()
                 .getTcpSocket().getPort().getIntVal().intValue(), 8080, "TCP port in readiness probe is missing.");
         
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
      * Validate if Dockerfile is created.
      */
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
@@ -196,7 +196,7 @@ public class ReadinessProbeTest {
      * Validate contents of the Dockerfile.
      */
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        ImageInfo imageInspect = getDockerImage(dockerImage);
+        ImageInfo imageInspect = getDockerImage(DOCKER_IMAGE);
         Assert.assertNotEquals(imageInspect, null, "Image not found");
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample11Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample11Test.java
@@ -20,18 +20,25 @@ package org.ballerinax.kubernetes.test.samples;
 
 import com.spotify.docker.client.messages.ImageInfo;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.batch.Job;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
+import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
@@ -39,43 +46,55 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getDocker
 
 public class Sample11Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample11";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_job:latest";
-
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample11");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_job:latest";
+    private Job job;
+    
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "hello_world_job.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world_job.bal"), 0);
+        File artifactYaml = TARGET_PATH.resolve("hello_world_job.yaml").toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(artifactYaml)).get();
+        for (HasMetadata data : k8sItems) {
+            if ("Job".equals(data.getKind())) {
+                job = (Job) data;
+            } else {
+                Assert.fail("Unexpected k8s resource found: " + data.getKind());
+            }
+        }
     }
 
+    @Test
+    public void validateJob() {
+        Assert.assertNotNull(job);
+        Assert.assertEquals("hello-world-job-job", job.getMetadata().getName());
+        Assert.assertEquals(job.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+        
+        Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(job.getSpec().getTemplate().getSpec()
+                .getRestartPolicy(), KubernetesConstants.RestartPolicy.Never.name());
+    }
+    
     @Test
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
-
+    
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        ImageInfo imageInspect = getDockerImage(dockerImage);
+        ImageInfo imageInspect = getDockerImage(DOCKER_IMAGE);
         Assert.assertNotNull(imageInspect.config());
-    }
-
-    @Test
-    public void validateJob() throws IOException {
-        File jobYAML = new File(targetPath + File.separator + "hello_world_job_job.yaml");
-        Job job = KubernetesTestUtils.loadYaml(jobYAML);
-        Assert.assertEquals("hello-world-job-job", job.getMetadata().getName());
-        Assert.assertEquals(1, job.getSpec().getTemplate().getSpec().getContainers().size());
-        Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(KubernetesConstants.RestartPolicy.Never.name(), job.getSpec().getTemplate().getSpec()
-                .getRestartPolicy());
     }
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-//        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample12Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample12Test.java
@@ -19,7 +19,10 @@
 package org.ballerinax.kubernetes.test.samples;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
@@ -31,7 +34,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -39,53 +44,68 @@ import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
 import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
 public class Sample12Test implements SampleTest {
-
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample12";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_copy_file:latest";
-
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample12");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_copy_file:latest";
+    private Deployment deployment;
+    
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "hello_world_copy_file.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world_copy_file.bal"), 0);
+        File artifactYaml = TARGET_PATH.resolve("hello_world_copy_file.yaml").toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(artifactYaml)).get();
+        for (HasMetadata data : k8sItems) {
+            switch (data.getKind()) {
+                case "Deployment":
+                    deployment = (Deployment) data;
+                    break;
+                case "Service":
+                case "Ingress":
+                case "Secret":
+                    break;
+                default:
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
+                    break;
+            }
+        }
     }
 
+    @Test
+    public void validateDeployment() {
+        Assert.assertNotNull(deployment);
+        Assert.assertEquals(deployment.getMetadata().getName(), "hello-world-copy-file-deployment");
+        Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getVolumes().size(), 1);
+        Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), "hello_world_copy_file");
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+
+        // Assert Containers
+        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Assert.assertEquals(container.getVolumeMounts().size(), 1);
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(container.getPorts().size(), 1);
+    }
+    
     @Test
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
-
+    
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
-    @Test
-    public void validateDeployment() throws IOException {
-        File deploymentYAML = new File(targetPath + File.separator + "hello_world_copy_file_deployment.yaml");
-        Assert.assertTrue(deploymentYAML.exists());
-        Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
-        // Assert Deployment
-        Assert.assertEquals("hello-world-copy-file-deployment", deployment.getMetadata().getName());
-        Assert.assertEquals(1, deployment.getSpec().getReplicas().intValue());
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getVolumes().size());
-        Assert.assertEquals("hello_world_copy_file", deployment.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-
-        // Assert Containers
-        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(1, container.getVolumeMounts().size());
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(1, container.getPorts().size());
-    }
-
     @AfterClass
-    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+    public void cleanUp() throws KubernetesPluginException {
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample13Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample13Test.java
@@ -27,8 +27,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -37,56 +37,53 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample13Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample13";
-    private final String targetPath = sourceDirPath + File.separator + "target" + File.separator + KUBERNETES;
-    private final String coolDrinkPkgTargetPath = targetPath + File.separator + "cool_drink";
-    private final String drinkStorePkgTargetPath = targetPath + File.separator + "drink_store";
-    private final String hotDrinkPkgTargetPath = targetPath + File.separator + "hot_drink";
-    private final String coolDrinkDockerImage = "cool_drink:latest";
-    private final String drinkStoreDockerImage = "drink_store:latest";
-    private final String hotDrinkDockerImage = "hot_drink:latest";
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample13");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve("target").resolve(KUBERNETES);
+    private static final Path COOL_DRINK_PKG_TARGET_PATH = TARGET_PATH.resolve("cool_drink");
+    private static final Path DRINK_STORE_PKG_TARGET_PATH = TARGET_PATH.resolve("drink_store");
+    private static final Path HOT_DRINK_PKG_TARGET_PATH = TARGET_PATH.resolve("hot_drink");
+    private static final String COOL_DRINK_DOCKER_IMAGE = "cool_drink:latest";
+    private static final String DRINK_STORE_DOCKER_IMAGE = "drink_store:latest";
+    private static final String HOT_DRINK_DOCKER_IMAGE = "hot_drink:latest";
 
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaProject((SAMPLE_DIR + File.separator + "sample13")), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaProject(SOURCE_DIR_PATH), 0);
     }
 
     @Test
     public void validateDockerfile() {
-        Assert.assertTrue(new File(coolDrinkPkgTargetPath + File.separator + DOCKER + File.separator + "Dockerfile")
-                .exists());
-        Assert.assertTrue(new File(drinkStorePkgTargetPath + File.separator + DOCKER + File.separator + "Dockerfile")
-                .exists());
-        Assert.assertTrue(new File(hotDrinkPkgTargetPath + File.separator + DOCKER + File.separator + "Dockerfile")
-                .exists());
+        Assert.assertTrue(COOL_DRINK_PKG_TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile().exists());
+        Assert.assertTrue(DRINK_STORE_PKG_TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile().exists());
+        Assert.assertTrue(HOT_DRINK_PKG_TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile().exists());
     }
 
     @Test
     public void validateDockerImageCoolDrink() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(coolDrinkDockerImage);
+        List<String> ports = getExposedPorts(COOL_DRINK_DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @Test
     public void validateDockerImageDrinkStore() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(drinkStoreDockerImage);
+        List<String> ports = getExposedPorts(DRINK_STORE_DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9091/tcp");
     }
     
     @Test
     public void validateDockerImageHotDrink() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(hotDrinkDockerImage);
+        List<String> ports = getExposedPorts(HOT_DRINK_DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(drinkStoreDockerImage);
-        KubernetesTestUtils.deleteDockerImage(coolDrinkDockerImage);
-        KubernetesTestUtils.deleteDockerImage(hotDrinkDockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DRINK_STORE_DOCKER_IMAGE);
+        KubernetesTestUtils.deleteDockerImage(COOL_DRINK_DOCKER_IMAGE);
+        KubernetesTestUtils.deleteDockerImage(HOT_DRINK_DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample15Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample15Test.java
@@ -18,6 +18,7 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
@@ -30,43 +31,35 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
 import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
 import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
 
-
 public class Sample15Test implements SampleTest {
-    
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample15";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_k8s_rq:latest";
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample15");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_k8s_rq:latest";
+    private ResourceQuota resourceQuota;
     
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "hello_world_k8s_rq.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world_k8s_rq.bal"), 0);
+        File yamlFile = TARGET_PATH.resolve("hello_world_k8s_rq.yaml").toFile();
+        Assert.assertTrue(yamlFile.exists());
+        List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(yamlFile);
+        for (HasMetadata data : k8sItems) {
+            if ("ResourceQuota".equals(data.getKind())) {
+                resourceQuota = (ResourceQuota) data;
+            }
+        }
     }
     
     @Test
-    public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
-        Assert.assertTrue(dockerFile.exists());
-    }
-    
-    @Test
-    public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
-        Assert.assertEquals(ports.size(), 1);
-        Assert.assertEquals(ports.get(0), "9090/tcp");
-    }
-    
-    @Test
-    public void validateResourceQuota() throws IOException {
-        File resourceQuotaYAML = new File(targetPath + File.separator + "hello_world_k8s_rq_resource_quota.yaml");
-        Assert.assertTrue(resourceQuotaYAML.exists());
-        ResourceQuota resourceQuota = KubernetesTestUtils.loadYaml(resourceQuotaYAML);
-        // Assert Resource quota
+    public void validateResourceQuota() {
+        Assert.assertNotNull(resourceQuota);
         Assert.assertEquals("pod-limit", resourceQuota.getMetadata().getName());
         Assert.assertEquals(resourceQuota.getMetadata().getLabels().size(), 0, "Invalid number of labels.");
     
@@ -84,9 +77,22 @@ public class Sample15Test implements SampleTest {
         Assert.assertEquals(resourceQuota.getSpec().getScopes().size(), 0, "Unexpected number of scopes.");
     }
     
+    @Test
+    public void validateDockerfile() {
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
+        Assert.assertTrue(dockerFile.exists());
+    }
+    
+    @Test
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
+    }
+    
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample16Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample16Test.java
@@ -34,6 +34,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -43,55 +44,52 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample16Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample16";
-    private final String targetPath = sourceDirPath + File.separator + "target" + File.separator + KUBERNETES;
-    private final String bookDetailsPkgTargetPath = targetPath + File.separator + "book.details";
-    private final String bookReviewsPkgTargetPath = targetPath + File.separator + "book.reviews";
-    private final String bookShopPkgTargetPath = targetPath + File.separator + "book.shop";
-    private final String bookDetailsDockerImage = "book.details:latest";
-    private final String bookReviewsDockerImage = "book.reviews:latest";
-    private final String bookShopDockerImage = "book.shop:latest";
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample16");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve("target").resolve(KUBERNETES);
+    private static final Path BOOK_DETAILS_PKG_TARGET_PATH = TARGET_PATH.resolve("book.details");
+    private static final Path BOOK_REVIEWS_PKG_TARGET_PATH = TARGET_PATH.resolve("book.reviews");
+    private static final Path BOOK_SHOP_PKG_TARGET_PATH = TARGET_PATH.resolve("book.shop");
+    private static final String BOOK_DETAILS_DOCKER_IMAGE = "book.details:latest";
+    private static final String BOOK_REVIEWS_DOCKER_IMAGE = "book.reviews:latest";
+    private static final String BOOK_SHOP_DOCKER_IMAGE = "book.shop:latest";
 
 
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaProject((SAMPLE_DIR + File.separator + "sample16")), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaProject(SOURCE_DIR_PATH), 0);
     }
 
     @Test
     public void validateDockerfile() {
-        Assert.assertTrue(new File(bookDetailsPkgTargetPath + File.separator + DOCKER + File.separator + "Dockerfile")
-                .exists());
-        Assert.assertTrue(new File(bookReviewsPkgTargetPath + File.separator + DOCKER + File.separator + "Dockerfile")
-                .exists());
-        Assert.assertTrue(new File(bookShopPkgTargetPath + File.separator + DOCKER + File.separator + "Dockerfile")
-                .exists());
+        Assert.assertTrue(BOOK_DETAILS_PKG_TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile().exists());
+        Assert.assertTrue(BOOK_REVIEWS_PKG_TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile().exists());
+        Assert.assertTrue(BOOK_SHOP_PKG_TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile().exists());
     }
 
     @Test
     public void validateDockerImageBookDetails() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(bookDetailsDockerImage);
+        List<String> ports = getExposedPorts(BOOK_DETAILS_DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "8080/tcp");
     }
 
     @Test
     public void validateDockerImageBookReviews() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(bookReviewsDockerImage);
+        List<String> ports = getExposedPorts(BOOK_REVIEWS_DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "7070/tcp");
     }
     
     @Test
     public void validateDockerImageBookShop() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(bookShopDockerImage);
+        List<String> ports = getExposedPorts(BOOK_SHOP_DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9080/tcp");
     }
 
     @Test(enabled = false)
     public void validateShopDeployment() throws IOException {
-        File deploymentYAML = new File(bookShopPkgTargetPath + File.separator + "book.shop_deployment.yaml");
+        File deploymentYAML = new File(BOOK_SHOP_PKG_TARGET_PATH + File.separator + "book.shop_deployment.yaml");
         Assert.assertTrue(deploymentYAML.exists(), "Cannot find deployment yaml");
         Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
         // Assert Deployment
@@ -104,7 +102,7 @@ public class Sample16Test implements SampleTest {
 
         // Assert Containers
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(container.getImage(), bookShopDockerImage, "Invalid container image");
+        Assert.assertEquals(container.getImage(), BOOK_SHOP_DOCKER_IMAGE, "Invalid container image");
         Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
         Assert.assertEquals(container.getPorts().size(), 1, "Invalid number of container ports");
         Assert.assertEquals(container.getPorts().get(0).getContainerPort().intValue(), 9080, "Invalid container port");
@@ -112,7 +110,7 @@ public class Sample16Test implements SampleTest {
 
     @Test(enabled = false)
     public void validateShopGateway() {
-        File gatewayYAML = new File(bookShopPkgTargetPath + File.separator + "book.shop_istio_gateway.yaml");
+        File gatewayYAML = new File(BOOK_SHOP_PKG_TARGET_PATH + File.separator + "book.shop_istio_gateway.yaml");
         Assert.assertTrue(gatewayYAML.exists(), "Cannot find istio gateway");
         // Validate gateway yaml
         
@@ -142,7 +140,7 @@ public class Sample16Test implements SampleTest {
     
     @Test(enabled = false)
     public void validateShopVirtualService() {
-        File vsFile = new File(bookShopPkgTargetPath + File.separator + "book.shop_istio_virtual_service.yaml");
+        File vsFile = new File(BOOK_SHOP_PKG_TARGET_PATH + File.separator + "book.shop_istio_virtual_service.yaml");
         Assert.assertTrue(vsFile.exists(), "Cannot find istio virtual service");
         Yaml yamlProcessor = new Yaml();
         Map<String, Object> virtualSvc = (Map<String, Object>) yamlProcessor.load(FileUtils.readFileAsString(vsFile));
@@ -171,9 +169,9 @@ public class Sample16Test implements SampleTest {
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(bookReviewsDockerImage);
-        KubernetesTestUtils.deleteDockerImage(bookDetailsDockerImage);
-        KubernetesTestUtils.deleteDockerImage(bookShopDockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(BOOK_REVIEWS_DOCKER_IMAGE);
+        KubernetesTestUtils.deleteDockerImage(BOOK_DETAILS_DOCKER_IMAGE);
+        KubernetesTestUtils.deleteDockerImage(BOOK_SHOP_DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample2Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample2Test.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -43,18 +44,18 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample2Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample2";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_k8s_config:latest";
-    private final String selectorApp = "hello_world_k8s_config";
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample2");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_k8s_config:latest";
+    private static final String SELECTOR_APP = "hello_world_k8s_config";
     private Deployment deployment;
     private Service service;
     private Ingress ingress;
 
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "hello_world_k8s_config.bal"), 0);
-        File yamlFile = new File(targetPath + File.separator + "hello_world_k8s_config.yaml");
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world_k8s_config.bal"), 0);
+        File yamlFile = new File(TARGET_PATH + File.separator + "hello_world_k8s_config.yaml");
         Assert.assertTrue(yamlFile.exists());
         List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(yamlFile);
         for (HasMetadata data : k8sItems) {
@@ -77,62 +78,62 @@ public class Sample2Test implements SampleTest {
     @Test
     public void validateDeployment() {
         Assert.assertNotNull(deployment);
-        Assert.assertEquals("hello-world-k8s-config-deployment", deployment.getMetadata().getName());
-        Assert.assertEquals(1, deployment.getSpec().getReplicas().intValue());
-        Assert.assertEquals(selectorApp, deployment.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
+        Assert.assertEquals(deployment.getMetadata().getName(), "hello-world-k8s-config-deployment");
+        Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+        Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(1, container.getPorts().size());
-        Assert.assertEquals(0, container.getEnv().size());
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(container.getPorts().size(), 1);
+        Assert.assertEquals(container.getEnv().size(), 0);
     }
 
     @Test
     public void validateK8SService() {
         Assert.assertNotNull(service);
-        Assert.assertEquals("hello", service.getMetadata().getName());
-        Assert.assertEquals(selectorApp, service.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), service.getSpec().getType());
-        Assert.assertEquals(1, service.getSpec().getPorts().size());
-        Assert.assertEquals(9090, service.getSpec().getPorts().get(0).getPort().intValue());
+        Assert.assertEquals(service.getMetadata().getName(), "hello");
+        Assert.assertEquals(service.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+        Assert.assertEquals(service.getSpec().getPorts().size(), 1);
+        Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), 9090);
     }
 
     @Test(dependsOnMethods = {"validateK8SService"})
     public void validateIngress() {
         Assert.assertNotNull(ingress);
-        Assert.assertEquals("helloep-ingress", ingress.getMetadata().getName());
-        Assert.assertEquals(selectorApp, ingress.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals("abc.com", ingress.getSpec().getRules().get(0).getHost());
-        Assert.assertEquals("/", ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
+        Assert.assertEquals(ingress.getMetadata().getName(), "helloep-ingress");
+        Assert.assertEquals(ingress.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(ingress.getSpec().getRules().get(0).getHost(), "abc.com");
+        Assert.assertEquals(ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), "/");
         Assert.assertEquals(service.getMetadata().getName(), ingress.getSpec().getRules().get(0).getHttp().getPaths()
                 .get(0).getBackend()
                 .getServiceName());
         Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), ingress.getSpec().getRules()
                 .get(0).getHttp().getPaths().get(0).getBackend()
                 .getServicePort().getIntVal().intValue());
-        Assert.assertEquals(2, ingress.getMetadata().getAnnotations().size());
+        Assert.assertEquals(ingress.getMetadata().getAnnotations().size(), 2);
     }
 
     @Test
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
 
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample3Test.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
@@ -33,7 +35,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -42,117 +46,106 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample3Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample3";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "foodstore:latest";
-    private final String selectorApp = "foodstore";
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample3");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "foodstore:latest";
+    private static final String SELECTOR_APP = "foodstore";
+    private Deployment deployment;
     private Service pizzaSvc;
     private Service burgerSvc;
-
+    private Ingress pizzaIngress;
+    private Ingress burgerIngress;
+    
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "foodstore.bal"), 0);
-    }
-
-    @Test
-    public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
-        Assert.assertTrue(dockerFile.exists());
-    }
-
-    @Test
-    public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
-        Assert.assertEquals(ports.size(), 2);
-        Assert.assertEquals(ports.get(0), "9096/tcp");
-        Assert.assertEquals(ports.get(1), "9099/tcp");
-    }
-
-    @Test
-    public void validateDeployment() throws IOException {
-        File deploymentYAML = new File(targetPath + File.separator + "foodstore_deployment.yaml");
-        Assert.assertTrue(deploymentYAML.exists());
-        Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
-        Assert.assertEquals(selectorApp, deployment.getMetadata().getName());
-        Assert.assertEquals(3, deployment.getSpec().getReplicas().intValue());
-        Assert.assertEquals(selectorApp, deployment.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(2, container.getPorts().size());
-        Assert.assertEquals(0, container.getEnv().size());
-        Assert.assertEquals(5, container.getLivenessProbe().getPeriodSeconds().intValue());
-        Assert.assertEquals(10, container.getLivenessProbe().getInitialDelaySeconds().intValue());
-    }
-
-    @Test
-    public void validateK8SService() throws IOException {
-        File serviceYAML = new File(targetPath + File.separator + "foodstore_svc.yaml");
-        Assert.assertTrue(serviceYAML.exists());
-        List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(serviceYAML);
-        Assert.assertEquals(2, k8sItems.size());
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "foodstore.bal"), 0);
+        File artifactYaml = TARGET_PATH.resolve("foodstore.yaml").toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(artifactYaml)).get();
         for (HasMetadata data : k8sItems) {
-            switch (data.getMetadata().getName()) {
-                case "pizzaep-svc":
-                    pizzaSvc = (Service) data;
+            switch (data.getKind()) {
+                case "Deployment":
+                    deployment = (Deployment) data;
                     break;
-                case "burgerep-svc":
-                    burgerSvc = (Service) data;
+                case "Service":
+                    switch (data.getMetadata().getName()) {
+                        case "pizzaep-svc":
+                            pizzaSvc = (Service) data;
+                            break;
+                        case "burgerep-svc":
+                            burgerSvc = (Service) data;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                case "Ingress":
+                    switch (data.getMetadata().getName()) {
+                        case "pizzaep-ingress":
+                            pizzaIngress = (Ingress) data;
+                            break;
+                        case "burgerep-ingress":
+                            burgerIngress = (Ingress) data;
+                            break;
+                        default:
+                            break;
+                    }
                     break;
                 default:
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
+    }
 
-        // Assert pizzaSvc
+    @Test
+    public void validateDeployment() {
+        Assert.assertNotNull(deployment);
+        Assert.assertEquals(deployment.getMetadata().getName(), SELECTOR_APP);
+        Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 3);
+        Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(container.getPorts().size(), 2);
+        Assert.assertEquals(container.getEnv().size(), 0);
+        Assert.assertEquals(container.getLivenessProbe().getPeriodSeconds().intValue(), 5);
+        Assert.assertEquals(container.getLivenessProbe().getInitialDelaySeconds().intValue(), 10);
+    }
+
+    @Test
+    public void validateK8SService() {
         Assert.assertNotNull(pizzaSvc);
-        Assert.assertEquals("pizzaep-svc", pizzaSvc.getMetadata().getName());
-        Assert.assertEquals(selectorApp, pizzaSvc.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), pizzaSvc.getSpec().getType());
-        Assert.assertEquals(1, pizzaSvc.getSpec().getPorts().size());
-        Assert.assertEquals(9099, pizzaSvc.getSpec().getPorts().get(0).getPort().intValue());
-        Assert.assertEquals("ClientIP", pizzaSvc.getSpec().getSessionAffinity());
+        Assert.assertEquals(pizzaSvc.getMetadata().getName(), "pizzaep-svc");
+        Assert.assertEquals(pizzaSvc.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(pizzaSvc.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+        Assert.assertEquals(pizzaSvc.getSpec().getPorts().size(), 1);
+        Assert.assertEquals(pizzaSvc.getSpec().getPorts().get(0).getPort().intValue(), 9099);
+        Assert.assertEquals(pizzaSvc.getSpec().getSessionAffinity(), "ClientIP");
 
         // Assert burgerSvc
         Assert.assertNotNull(burgerSvc);
-        Assert.assertEquals("burgerep-svc", burgerSvc.getMetadata().getName());
-        Assert.assertEquals(selectorApp, burgerSvc.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), burgerSvc.getSpec().getType());
-        Assert.assertEquals(1, burgerSvc.getSpec().getPorts().size());
-        Assert.assertEquals(9096, burgerSvc.getSpec().getPorts().get(0).getPort().intValue());
+        Assert.assertEquals(burgerSvc.getMetadata().getName(), "burgerep-svc");
+        Assert.assertEquals(burgerSvc.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(burgerSvc.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+        Assert.assertEquals(burgerSvc.getSpec().getPorts().size(), 1);
+        Assert.assertEquals(burgerSvc.getSpec().getPorts().get(0).getPort().intValue(), 9096);
     }
 
     @Test(dependsOnMethods = {"validateK8SService"})
-    public void validateIngress() throws IOException {
-        File ingressYAML = new File(targetPath + File.separator + "foodstore_ingress.yaml");
-        Assert.assertTrue(ingressYAML.exists());
-        List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(ingressYAML);
-        Assert.assertEquals(2, k8sItems.size());
-        Ingress pizzaIngress = null;
-        Ingress burgerIngress = null;
-        for (HasMetadata data : k8sItems) {
-            switch (data.getMetadata().getName()) {
-                case "pizzaep-ingress":
-                    pizzaIngress = (Ingress) data;
-                    break;
-                case "burgerep-ingress":
-                    burgerIngress = (Ingress) data;
-                    break;
-                default:
-                    break;
-            }
-        }
+    public void validateIngress() {
         // Assert Burger ingress
         Assert.assertNotNull(burgerIngress);
-        Assert.assertEquals("burgerep-ingress", burgerIngress.getMetadata().getName());
-        Assert.assertEquals(selectorApp, burgerIngress.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals("burger.com", burgerIngress.getSpec().getRules().get(0).getHost());
-        Assert.assertEquals("/", burgerIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
+        Assert.assertEquals(burgerIngress.getMetadata().getName(), "burgerep-ingress");
+        Assert.assertEquals(burgerIngress.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(burgerIngress.getSpec().getRules().get(0).getHost(), "burger.com");
+        Assert.assertEquals(burgerIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), "/");
         Assert.assertEquals(burgerSvc.getMetadata().getName(), burgerIngress.getSpec().getRules().get(0).getHttp()
                 .getPaths()
                 .get(0).getBackend()
@@ -161,16 +154,16 @@ public class Sample3Test implements SampleTest {
                 .getRules()
                 .get(0).getHttp().getPaths().get(0).getBackend()
                 .getServicePort().getIntVal().intValue());
-        Assert.assertEquals(3, burgerIngress.getMetadata().getAnnotations().size());
+        Assert.assertEquals(burgerIngress.getMetadata().getAnnotations().size(), 3);
 
         // Assert Pizza ingress
         Assert.assertNotNull(pizzaIngress);
-        Assert.assertEquals("pizzaep-ingress", pizzaIngress.getMetadata().getName());
-        Assert.assertEquals(selectorApp, pizzaIngress.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals("pizza.com", pizzaIngress.getSpec().getRules().get(0).getHost());
-        Assert.assertEquals("/pizzastore", pizzaIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0)
-                .getPath());
+        Assert.assertEquals(pizzaIngress.getMetadata().getName(), "pizzaep-ingress");
+        Assert.assertEquals(pizzaIngress.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(pizzaIngress.getSpec().getRules().get(0).getHost(), "pizza.com");
+        Assert.assertEquals(pizzaIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(),
+                "/pizzastore");
         Assert.assertEquals(pizzaSvc.getMetadata().getName(), pizzaIngress.getSpec().getRules().get(0).getHttp()
                 .getPaths()
                 .get(0).getBackend()
@@ -179,12 +172,26 @@ public class Sample3Test implements SampleTest {
                 .getRules()
                 .get(0).getHttp().getPaths().get(0).getBackend()
                 .getServicePort().getIntVal().intValue());
-        Assert.assertEquals(3, pizzaIngress.getMetadata().getAnnotations().size());
+        Assert.assertEquals(pizzaIngress.getMetadata().getAnnotations().size(), 3);
+    }
+    
+    @Test
+    public void validateDockerfile() {
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
+        Assert.assertTrue(dockerFile.exists());
+    }
+    
+    @Test
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
+        Assert.assertEquals(ports.size(), 2);
+        Assert.assertEquals(ports.get(0), "9096/tcp");
+        Assert.assertEquals(ports.get(1), "9099/tcp");
     }
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample4Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample4Test.java
@@ -19,9 +19,12 @@
 package org.ballerinax.kubernetes.test.samples;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
@@ -33,7 +36,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -42,85 +47,103 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample4Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample4";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_ssl_k8s:latest";
-    private final String selectorApp = "hello_world_ssl_k8s";
-
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample4");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_ssl_k8s:latest";
+    private static final String SELECTOR_APP = "hello_world_ssl_k8s";
+    private Deployment deployment;
+    private Secret secret;
+    private Ingress ingress;
+    
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "hello_world_ssl_k8s.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world_ssl_k8s.bal"), 0);
+        File artifactYaml = TARGET_PATH.resolve("hello_world_ssl_k8s.yaml").toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(artifactYaml)).get();
+        for (HasMetadata data : k8sItems) {
+            switch (data.getKind()) {
+                case "Deployment":
+                    deployment = (Deployment) data;
+                    break;
+                case "Secret":
+                    secret = (Secret) data;
+                    break;
+                case "Ingress":
+                    ingress = (Ingress) data;
+                    break;
+                case "Service":
+                    break;
+                default:
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
+                    break;
+            }
+        }
     }
 
+    @Test
+    public void validateDeployment() {
+        Assert.assertNotNull(deployment);
+        Assert.assertEquals(deployment.getMetadata().getName(), "hello-world-ssl-k8s-deployment");
+        Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getVolumes()
+                .get(0).getSecret().getSecretName(), "helloworldsecuredep-keystore");
+        Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+
+        // Assert Containers
+        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Assert.assertEquals(container.getVolumeMounts().size(), 1);
+        Assert.assertEquals(container.getVolumeMounts().get(0).getMountPath(), "/ballerina/runtime/bre/security");
+        Assert.assertEquals(container.getVolumeMounts().get(0).getName(), "helloworldsecuredep-keystore-volume");
+        Assert.assertTrue(container.getVolumeMounts().get(0).getReadOnly());
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(container.getPorts().size(), 1);
+    }
+
+    @Test
+    public void validateSecret() {
+        Assert.assertNotNull(secret);
+        Assert.assertEquals(secret.getMetadata().getName(), "helloworldsecuredep-keystore");
+        Assert.assertEquals(secret.getData().size(), 1);
+    }
+
+    @Test
+    public void validateIngress() {
+        Assert.assertNotNull(ingress);
+        Assert.assertEquals(ingress.getMetadata().getName(), "helloworldsecuredep-ingress");
+        Assert.assertEquals(ingress.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), SELECTOR_APP);
+        Assert.assertEquals(ingress.getSpec().getRules().get(0).getHost(), "abc.com");
+        Assert.assertEquals(ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath(), "/");
+        Assert.assertTrue(ingress.getMetadata().getAnnotations().containsKey(
+                "nginx.ingress.kubernetes.io/ssl-passthrough"));
+        Assert.assertTrue(Boolean.valueOf(ingress.getMetadata().getAnnotations().get(
+                "nginx.ingress.kubernetes.io/ssl-passthrough")));
+        Assert.assertEquals(ingress.getSpec().getTls().size(), 1);
+        Assert.assertEquals(ingress.getSpec().getTls().get(0).getHosts().size(), 1);
+        Assert.assertEquals(ingress.getSpec().getTls().get(0).getHosts().get(0), "abc.com");
+    }
+    
     @Test
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
-
+    
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
-    @Test
-    public void validateDeployment() throws IOException {
-        File deploymentYAML = new File(targetPath + File.separator + "hello_world_ssl_k8s_deployment.yaml");
-        Assert.assertTrue(deploymentYAML.exists());
-        Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
-        // Assert Deployment
-        Assert.assertEquals("hello-world-ssl-k8s-deployment", deployment.getMetadata().getName());
-        Assert.assertEquals(1, deployment.getSpec().getReplicas().intValue());
-        Assert.assertEquals("helloworldsecuredep-keystore", deployment.getSpec().getTemplate().getSpec().getVolumes()
-                .get(0).getSecret().getSecretName());
-        Assert.assertEquals(selectorApp, deployment.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-
-        // Assert Containers
-        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(1, container.getVolumeMounts().size());
-        Assert.assertEquals("/ballerina/runtime/bre/security", container.getVolumeMounts().get(0).getMountPath());
-        Assert.assertEquals("helloworldsecuredep-keystore-volume", container.getVolumeMounts().get(0).getName());
-        Assert.assertTrue(container.getVolumeMounts().get(0).getReadOnly().booleanValue());
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(1, container.getPorts().size());
-    }
-
-    @Test
-    public void validateSecret() throws IOException {
-        File secretYAML = new File(targetPath + File.separator + "hello_world_ssl_k8s_secret.yaml");
-        Assert.assertTrue(secretYAML.exists());
-        Secret secret = KubernetesTestUtils.loadYaml(secretYAML);
-        Assert.assertEquals("helloworldsecuredep-keystore", secret.getMetadata().getName());
-        Assert.assertEquals(1, secret.getData().size());
-    }
-
-    @Test
-    public void validateIngress() throws IOException {
-        File ingressYAML = new File(targetPath + File.separator + "hello_world_ssl_k8s_ingress.yaml");
-        Assert.assertNotNull(ingressYAML);
-        Ingress ingress = KubernetesTestUtils.loadYaml(ingressYAML);
-        Assert.assertEquals("helloworldsecuredep-ingress", ingress.getMetadata().getName());
-        Assert.assertEquals(selectorApp, ingress.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals("abc.com", ingress.getSpec().getRules().get(0).getHost());
-        Assert.assertEquals("/", ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
-        Assert.assertTrue(ingress.getMetadata().getAnnotations().containsKey("nginx.ingress.kubernetes" +
-                ".io/ssl-passthrough"));
-        Assert.assertTrue(Boolean.valueOf(ingress.getMetadata().getAnnotations().get("nginx.ingress.kubernetes" +
-                ".io/ssl-passthrough")));
-        Assert.assertEquals(1, ingress.getSpec().getTls().size());
-        Assert.assertEquals(1, ingress.getSpec().getTls().get(0).getHosts().size());
-        Assert.assertEquals("abc.com", ingress.getSpec().getTls().get(0).getHosts().get(0));
-    }
-
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample5Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample5Test.java
@@ -18,7 +18,10 @@
 
 package org.ballerinax.kubernetes.test.samples;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
@@ -30,7 +33,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -39,34 +44,38 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample5Test implements SampleTest {
     
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample5";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "ballerina.com/pizzashack:2.1.0";
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample5");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "ballerina.com/pizzashack:2.1.0";
+    private HorizontalPodAutoscaler podAutoscaler;
     
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "pizzashack.bal"), 0);
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "pizzashack.bal"), 0);
+        File artifactYaml = TARGET_PATH.resolve("pizzashack.yaml").toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(artifactYaml)).get();
+        for (HasMetadata data : k8sItems) {
+            switch (data.getKind()) {
+                case "HorizontalPodAutoscaler":
+                    podAutoscaler = (HorizontalPodAutoscaler) data;
+                    break;
+                case "Service":
+                case "Ingress":
+                case "Secret":
+                case "Deployment":
+                    break;
+                default:
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
+                    break;
+            }
+        }
     }
     
     @Test
-    public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
-        Assert.assertTrue(dockerFile.exists());
-    }
-    
-    @Test
-    public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
-        Assert.assertEquals(ports.size(), 2);
-        Assert.assertEquals(ports.get(0), "9090/tcp");
-        Assert.assertEquals(ports.get(1), "9095/tcp");
-    }
-    
-    @Test
-    public void validatePodAutoscaler() throws IOException {
-        File hpaYAML = new File(targetPath + File.separator + "pizzashack_hpa.yaml");
-        Assert.assertTrue(hpaYAML.exists());
-        HorizontalPodAutoscaler podAutoscaler = KubernetesTestUtils.loadYaml(hpaYAML);
+    public void validatePodAutoscaler() {
+        Assert.assertNotNull(podAutoscaler);
         Assert.assertEquals(podAutoscaler.getMetadata().getName(), "pizzashack-hpa");
         Assert.assertEquals(podAutoscaler.getMetadata().getLabels().get(KubernetesConstants
                 .KUBERNETES_SELECTOR_KEY), "pizzashack");
@@ -80,9 +89,23 @@ public class Sample5Test implements SampleTest {
         Assert.assertEquals(podAutoscaler.getSpec().getScaleTargetRef().getName(), "pizzashack-deployment");
     }
     
+    @Test
+    public void validateDockerfile() {
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
+        Assert.assertTrue(dockerFile.exists());
+    }
+    
+    @Test
+    public void validateDockerImage() throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
+        Assert.assertEquals(ports.size(), 2);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
+        Assert.assertEquals(ports.get(1), "9095/tcp");
+    }
+    
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample8Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample8Test.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
@@ -33,7 +35,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -43,62 +47,74 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample8Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample8";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_config_map_k8s:latest";
-
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample8");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_config_map_k8s:latest";
+    private Deployment deployment;
+    private ConfigMap ballerinaConf;
+    private ConfigMap dataMap;
+    
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath, "hello_world_config_map_k8s.bal")
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "hello_world_config_map_k8s.bal")
                 , 0);
-    }
-
-    @Test
-    public void validateDeployment() throws IOException {
-        File deploymentYAML = new File(targetPath + File.separator + "hello_world_config_map_k8s_deployment.yaml");
-        Assert.assertTrue(deploymentYAML.exists());
-        Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
-        // Assert Deployment
-        Assert.assertEquals("hello-world-config-map-k8s-deployment", deployment.getMetadata().getName());
-        Assert.assertEquals(1, deployment.getSpec().getReplicas().intValue());
-        Assert.assertEquals(3, deployment.getSpec().getTemplate().getSpec().getVolumes().size());
-        Assert.assertEquals("hello_world_config_map_k8s", deployment.getMetadata().getLabels().get(KubernetesConstants
-                .KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-
-        // Assert Containers
-        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(3, container.getVolumeMounts().size());
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(1, container.getPorts().size());
-        Assert.assertEquals(1, container.getEnv().size());
-
-        //Validate config file
-        Assert.assertEquals("CONFIG_FILE", container.getEnv().get(0).getName());
-        Assert.assertEquals("/home/ballerina/conf/ballerina.conf", container.getEnv().get(0).getValue());
-    }
-
-    @Test
-    public void validateConfigMap() throws IOException {
-        File secretYAML = new File(targetPath + File.separator + "hello_world_config_map_k8s_config_map.yaml");
-        Assert.assertTrue(secretYAML.exists());
-        List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(secretYAML);
-        Assert.assertEquals(2, k8sItems.size());
-        ConfigMap ballerinaConf = null;
-        ConfigMap dataMap = null;
+        File artifactYaml = TARGET_PATH.resolve("hello_world_config_map_k8s.yaml").toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(artifactYaml)).get();
         for (HasMetadata data : k8sItems) {
-            switch (data.getMetadata().getName()) {
-                case "helloworld-ballerina-conf-config-map":
-                    ballerinaConf = (ConfigMap) data;
+            switch (data.getKind()) {
+                case "Deployment":
+                    deployment = (Deployment) data;
                     break;
-                case "helloworld-config-map":
-                    dataMap = (ConfigMap) data;
+                case "ConfigMap":
+                    switch (data.getMetadata().getName()) {
+                        case "helloworld-ballerina-conf-config-map":
+                            ballerinaConf = (ConfigMap) data;
+                            break;
+                        case "helloworld-config-map":
+                            dataMap = (ConfigMap) data;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                case "Service":
+                case "Secret":
+                case "Ingress":
                     break;
                 default:
+                    Assert.fail("Unexpected k8s resource found: " + data.getKind());
                     break;
             }
         }
+    }
+
+    @Test
+    public void validateDeployment() {
+        Assert.assertNotNull(deployment);
+        Assert.assertEquals(deployment.getMetadata().getName(), "hello-world-config-map-k8s-deployment");
+        Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getVolumes().size(), 3);
+        Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                .KUBERNETES_SELECTOR_KEY), "hello_world_config_map_k8s");
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+
+        // Assert Containers
+        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Assert.assertEquals(container.getVolumeMounts().size(), 3);
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(container.getPorts().size(), 1);
+        Assert.assertEquals(container.getEnv().size(), 1);
+
+        // Validate config file
+        Assert.assertEquals(container.getEnv().get(0).getName(), "CONFIG_FILE");
+        Assert.assertEquals(container.getEnv().get(0).getValue(), "/home/ballerina/conf/ballerina.conf");
+    }
+
+    @Test
+    public void validateConfigMap() {
         // Assert ballerina.conf config map
         Assert.assertNotNull(ballerinaConf);
         Assert.assertEquals(1, ballerinaConf.getData().size());
@@ -110,24 +126,23 @@ public class Sample8Test implements SampleTest {
 
     @Test
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
 
     @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
         // Validate ballerina.conf in run command
-        Assert.assertEquals(getCommand(this.dockerImage).toString(),
+        Assert.assertEquals(getCommand(DOCKER_IMAGE).toString(),
                             "[/bin/sh, -c, ballerina run --config ${CONFIG_FILE} hello_world_config_map_k8s.balx]");
     }
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
-
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample9Test.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/Sample9Test.java
@@ -19,6 +19,7 @@
 package org.ballerinax.kubernetes.test.samples;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import org.ballerinax.kubernetes.KubernetesConstants;
@@ -33,6 +34,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
@@ -41,65 +43,74 @@ import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExpose
 
 public class Sample9Test implements SampleTest {
 
-    private final String sourceDirPath = SAMPLE_DIR + File.separator + "sample9";
-    private final String targetPath = sourceDirPath + File.separator + KUBERNETES;
-    private final String dockerImage = "hello_world_persistence_volume_k8s:latest";
-
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("sample9");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(KUBERNETES);
+    private static final String DOCKER_IMAGE = "hello_world_persistence_volume_k8s:latest";
+    private Deployment deployment;
+    private PersistentVolumeClaim volumeClaim;
+    
     @BeforeClass
     public void compileSample() throws IOException, InterruptedException {
-        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(sourceDirPath,
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(SOURCE_DIR_PATH,
                 "hello_world_persistence_volume_k8s.bal") , 0);
+        File yamlFile = TARGET_PATH.resolve("hello_world_persistence_volume_k8s.yaml").toFile();
+        Assert.assertTrue(yamlFile.exists());
+        List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(yamlFile);
+        for (HasMetadata data : k8sItems) {
+            switch (data.getKind()) {
+                case "Deployment":
+                    deployment = (Deployment) data;
+                    break;
+                case "PersistentVolumeClaim":
+                    volumeClaim = (PersistentVolumeClaim) data;
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     @Test
+    public void validateDeployment() {
+        Assert.assertNotNull(deployment);
+        Assert.assertEquals(deployment.getMetadata().getName(), "hello-world-persistence-volume-k8s-deployment");
+        Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getVolumes().size(), 2);
+        Assert.assertEquals(deployment.getMetadata().getLabels().get
+                (KubernetesConstants.KUBERNETES_SELECTOR_KEY), "hello_world_persistence_volume_k8s");
+        Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+
+        // Assert Containers
+        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        Assert.assertEquals(container.getVolumeMounts().size(), 2);
+        Assert.assertEquals(container.getImage(), DOCKER_IMAGE);
+        Assert.assertEquals(container.getImagePullPolicy(), KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+        Assert.assertEquals(container.getPorts().size(), 1);
+    }
+
+    @Test
+    public void validateVolumeClaim() {
+        Assert.assertNotNull(volumeClaim);
+        Assert.assertEquals(volumeClaim.getMetadata().getName(), "local-pv-2");
+        Assert.assertEquals(volumeClaim.getSpec().getAccessModes().size(), 1);
+    }
+    
+    @Test
     public void validateDockerfile() {
-        File dockerFile = new File(targetPath + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
 
     @Test
-    public void validateDeployment() throws IOException {
-        File deploymentYAML = new File(targetPath + File.separator + "hello_world_persistence_volume_k8s_deployment" +
-                ".yaml");
-        Assert.assertTrue(deploymentYAML.exists());
-        Deployment deployment = KubernetesTestUtils.loadYaml(deploymentYAML);
-        // Assert Deployment
-        Assert.assertEquals("hello-world-persistence-volume-k8s-deployment", deployment.getMetadata().getName());
-        Assert.assertEquals(1, deployment.getSpec().getReplicas().intValue());
-        Assert.assertEquals(2, deployment.getSpec().getTemplate().getSpec().getVolumes().size());
-        Assert.assertEquals("hello_world_persistence_volume_k8s", deployment.getMetadata().getLabels().get
-                (KubernetesConstants.KUBERNETES_SELECTOR_KEY));
-        Assert.assertEquals(1, deployment.getSpec().getTemplate().getSpec().getContainers().size());
-
-        // Assert Containers
-        Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Assert.assertEquals(2, container.getVolumeMounts().size());
-        Assert.assertEquals(dockerImage, container.getImage());
-        Assert.assertEquals(KubernetesConstants.ImagePullPolicy.IfNotPresent.name(), container.getImagePullPolicy());
-        Assert.assertEquals(1, container.getPorts().size());
-    }
-
-    @Test
-    public void validateVolumeClaim() throws IOException {
-        File deploymentYAML = new File(targetPath + File.separator + "hello_world_persistence_volume_k8s_volume_claim" +
-                ".yaml");
-        Assert.assertTrue(deploymentYAML.exists());
-        PersistentVolumeClaim volumeClaim = KubernetesTestUtils.loadYaml(deploymentYAML);
-        // Assert Deployment
-        Assert.assertEquals("local-pv-2", volumeClaim.getMetadata().getName());
-        Assert.assertEquals(1, volumeClaim.getSpec().getAccessModes().size());
-    }
-
-    @Test
     public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(this.dockerImage);
+        List<String> ports = getExposedPorts(DOCKER_IMAGE);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
     }
 
     @AfterClass
     public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(targetPath);
-        KubernetesTestUtils.deleteDockerImage(dockerImage);
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/SampleTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/samples/SampleTest.java
@@ -24,9 +24,11 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public interface SampleTest {
-    String SAMPLE_DIR = System.getProperty("sample.dir");
+    Path SAMPLE_DIR = Paths.get(System.getProperty("sample.dir"));
 
     @BeforeClass
     void compileSample() throws IOException, InterruptedException;

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
@@ -235,15 +235,15 @@ public class KubernetesUtils {
     public static void printInstruction(String msg) {
         OUT.println(msg);
     }
-
+    
     /**
      * Deletes a given directory.
      *
      * @param path path to directory
      * @throws KubernetesPluginException if an error occurs while deleting
      */
-    public static void deleteDirectory(String path) throws KubernetesPluginException {
-        Path pathToBeDeleted = Paths.get(path);
+    public static void deleteDirectory(Path path) throws KubernetesPluginException {
+        Path pathToBeDeleted = path.toAbsolutePath();
         if (!Files.exists(pathToBeDeleted)) {
             return;
         }
@@ -255,17 +255,7 @@ public class KubernetesUtils {
         } catch (IOException e) {
             throw new KubernetesPluginException("unable to delete directory: " + path, e);
         }
-
-    }
     
-    /**
-     * Deletes a given directory.
-     *
-     * @param path path to directory
-     * @throws KubernetesPluginException if an error occurs while deleting
-     */
-    public static void deleteDirectory(Path path) throws KubernetesPluginException {
-        deleteDirectory(path.toAbsolutePath().toString());
     }
 
     /* Checks if a String is empty ("") or null.

--- a/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
+++ b/kubernetes-extension/src/test/java/org/ballerinax/kubernetes/utils/KubernetesUtilsTest.java
@@ -91,8 +91,8 @@ public class KubernetesUtilsTest {
         Assert.assertTrue(file.createNewFile());
         File directory = tempDirectory.resolve("subFolder").toFile();
         Assert.assertTrue(directory.mkdirs());
-        KubernetesUtils.deleteDirectory(file.getPath());
-        KubernetesUtils.deleteDirectory(directory.getPath());
+        KubernetesUtils.deleteDirectory(file.toPath());
+        KubernetesUtils.deleteDirectory(directory.toPath());
     }
 
     @Test

--- a/samples/sample1/hello_world_k8s.bal
+++ b/samples/sample1/hello_world_k8s.bal
@@ -2,9 +2,7 @@ import ballerina/http;
 import ballerinax/kubernetes;
 
 @kubernetes:Service { serviceType: "NodePort" }
-@kubernetes:Deployment {
-    singleYAML: false
-}
+@kubernetes:Deployment {}
 @http:ServiceConfig {
     basePath: "/helloWorld"
 }

--- a/samples/sample10/burger/burger_api.bal
+++ b/samples/sample10/burger/burger_api.bal
@@ -17,9 +17,7 @@ listener http:Listener burgerEP = new(9096, config = {
 });
 
 
-@kubernetes:Deployment {
-    singleYAML: false
-}
+@kubernetes:Deployment {}
 @http:ServiceConfig {
     basePath: "/burger"
 }

--- a/samples/sample10/pizza/pizza_api.bal
+++ b/samples/sample10/pizza/pizza_api.bal
@@ -15,8 +15,7 @@ listener http:Listener pizzaEP = new(9099);
     env: { "location": "SL", "city": "COLOMBO" },
     livenessProbe: {
         port: 9099
-    },
-    singleYAML: false
+    }
 }
 @http:ServiceConfig {
     basePath: "/pizza"

--- a/samples/sample11/hello_world_job.bal
+++ b/samples/sample11/hello_world_job.bal
@@ -1,9 +1,7 @@
 import ballerina/io;
 import ballerinax/kubernetes;
 
-@kubernetes:Job {
-    singleYAML: false
-}
+@kubernetes:Job {}
 public function main(string... args) {
     io:println("hello world");
 }

--- a/samples/sample12/hello_world_copy_file.bal
+++ b/samples/sample12/hello_world_copy_file.bal
@@ -25,8 +25,7 @@ listener http:Listener helloWorldEP = new(9090, config = {
             target: "/home/ballerina/data/data.txt",
             source: "./data/data.txt"
         }
-    ],
-    singleYAML: false
+    ]
 }
 @http:ServiceConfig {
     basePath: "/helloWorld"

--- a/samples/sample15/hello_world_k8s_rq.bal
+++ b/samples/sample15/hello_world_k8s_rq.bal
@@ -4,8 +4,7 @@ import ballerinax/kubernetes;
 @kubernetes:Deployment {
     livenessProbe: true,
     namespace: "ballerina",
-    replicas: 2,
-    singleYAML: false
+    replicas: 2
 }
 @kubernetes:Ingress {
     hostname: "abc.com"

--- a/samples/sample3/foodstore.bal
+++ b/samples/sample3/foodstore.bal
@@ -18,8 +18,7 @@ listener http:Listener pizzaEP = new(9099);
     labels: { "location": "SL", "city": "COLOMBO" },
     livenessProbe: {
         port: 9099
-    },
-    singleYAML: false
+    }
 }
 
 @http:ServiceConfig {

--- a/samples/sample4/hello_world_ssl_k8s.bal
+++ b/samples/sample4/hello_world_ssl_k8s.bal
@@ -14,9 +14,7 @@ listener http:Listener helloWorldSecuredEP = new(9090, config = {
     }
 });
 
-@kubernetes:Deployment {
-    singleYAML: false
-}
+@kubernetes:Deployment {}
 @http:ServiceConfig {
     basePath:"/helloWorld"
 }

--- a/samples/sample5/pizzashack.bal
+++ b/samples/sample5/pizzashack.bal
@@ -22,8 +22,7 @@ listener http:Listener pizzaEPSecured = new(9095, config = {
 
 
 @kubernetes:Deployment {
-    image: "ballerina.com/pizzashack:2.1.0",
-    singleYAML: false
+    image: "ballerina.com/pizzashack:2.1.0"
 }
 @kubernetes:HPA {}
 @http:ServiceConfig {

--- a/samples/sample7/hello_world_secret_mount_k8s.bal
+++ b/samples/sample7/hello_world_secret_mount_k8s.bal
@@ -34,9 +34,7 @@ listener http:Listener helloWorldEP = new(9090, config = {
     ]
 }
 
-@kubernetes:Deployment {
-    singleYAML: false
-}
+@kubernetes:Deployment {}
 @http:ServiceConfig {
     basePath: "/helloWorld"
 }

--- a/samples/sample8/hello_world_config_map_k8s.bal
+++ b/samples/sample8/hello_world_config_map_k8s.bal
@@ -20,9 +20,7 @@ listener http:Listener helloWorldEP = new(9090, config = {
     }
 });
 
-@kubernetes: Deployment {
-    singleYAML: false
-}
+@kubernetes: Deployment {}
 @kubernetes:ConfigMap {
     conf: "./conf/ballerina.conf",
     configMaps:[

--- a/samples/sample9/hello_world_persistence_volume_k8s.bal
+++ b/samples/sample9/hello_world_persistence_volume_k8s.bal
@@ -26,9 +26,7 @@ listener http:Listener helloWorldEP = new(9090, config = {
     ]
 }
 
-@kubernetes:Deployment {
-    singleYAML: false
-}
+@kubernetes:Deployment {}
 @http:ServiceConfig {
     basePath: "/helloWorld"
 }


### PR DESCRIPTION
## Purpose
> Remove `singleYAML: false` in samples. Move file related implementations to Java NIO paths than using Strings. Clean up code.
