### PR TITLE
Add targetPort field for @kubernetes:Service annotation

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/ServiceTest.java
@@ -21,17 +21,18 @@ package org.ballerinax.kubernetes.test;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.ballerinax.kubernetes.KubernetesConstants;
 import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
 import org.ballerinax.kubernetes.test.utils.DockerTestException;
 import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
 import org.ballerinax.kubernetes.utils.KubernetesUtils;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,16 +49,16 @@ public class ServiceTest {
     private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "svc");
     private static final Path TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
     private static final String DOCKER_IMAGE = "pizza-shop:latest";
-    private static final String SELECTOR_APP = "different_svc_ports";
-    private Service service;
-    private Ingress ingress;
     
-    @BeforeClass
-    public void compileSample() throws IOException, InterruptedException {
+    @Test
+    public void differentSvcPortTest() throws IOException, InterruptedException, DockerTestException,
+            KubernetesPluginException {
         Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "different_svc_ports.bal"), 0);
-        File yamlFile = new File(TARGET_PATH + File.separator + "different_svc_ports.yaml");
+        File yamlFile = TARGET_PATH.resolve("different_svc_ports.yaml").toFile();
         Assert.assertTrue(yamlFile.exists());
         List<HasMetadata> k8sItems = KubernetesTestUtils.loadYaml(yamlFile);
+        Service service = null;
+        Ingress ingress = null;
         for (HasMetadata data : k8sItems) {
             switch (data.getKind()) {
                 case "Service":
@@ -70,31 +71,22 @@ public class ServiceTest {
                     break;
             }
         }
-    }
     
-    /**
-     * Validate generated service yaml.
-     */
-    @Test
-    public void validateK8SService() {
+        validateDockerfile();
+        validateDockerImage(DOCKER_IMAGE);
+    
         Assert.assertNotNull(service);
         Assert.assertEquals("hello", service.getMetadata().getName());
-        Assert.assertEquals(SELECTOR_APP, service.getMetadata().getLabels().get(KubernetesConstants
+        Assert.assertEquals("different_svc_ports", service.getMetadata().getLabels().get(KubernetesConstants
                 .KUBERNETES_SELECTOR_KEY));
         Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), service.getSpec().getType());
         Assert.assertEquals(1, service.getSpec().getPorts().size());
         Assert.assertEquals(8080, service.getSpec().getPorts().get(0).getPort().intValue());
         Assert.assertEquals(9090, service.getSpec().getPorts().get(0).getTargetPort().getIntVal().intValue());
-    }
     
-    /**
-     * Validate generated ingress yaml.
-     */
-    @Test(dependsOnMethods = {"validateK8SService"})
-    public void validateIngress() {
         Assert.assertNotNull(ingress);
         Assert.assertEquals("helloep-ingress", ingress.getMetadata().getName());
-        Assert.assertEquals(SELECTOR_APP, ingress.getMetadata().getLabels().get(KubernetesConstants
+        Assert.assertEquals("different_svc_ports", ingress.getMetadata().getLabels().get(KubernetesConstants
                 .KUBERNETES_SELECTOR_KEY));
         Assert.assertEquals("abc.com", ingress.getSpec().getRules().get(0).getHost());
         Assert.assertEquals("/", ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
@@ -105,6 +97,9 @@ public class ServiceTest {
                 .get(0).getHttp().getPaths().get(0).getBackend()
                 .getServicePort().getIntVal().intValue());
         Assert.assertEquals(2, ingress.getMetadata().getAnnotations().size());
+    
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
     
     /**
@@ -118,21 +113,42 @@ public class ServiceTest {
     }
     
     @Test
+    public void portAndTargetPortTest() throws IOException, InterruptedException, KubernetesPluginException,
+            DockerTestException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "port_and_target_port.bal"), 0);
+        File yamlFile = TARGET_PATH.resolve("port_and_target_port.yaml").toFile();
+        Assert.assertTrue(yamlFile.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
+        for (HasMetadata data : k8sItems) {
+            if ("Service".equals(data.getKind())) {
+                Service service = (Service) data;
+                Assert.assertNotNull(service);
+                Assert.assertEquals("hello", service.getMetadata().getName());
+                Assert.assertEquals("port_and_target_port", service.getMetadata().getLabels().get(KubernetesConstants
+                        .KUBERNETES_SELECTOR_KEY));
+                Assert.assertEquals(KubernetesConstants.ServiceType.ClusterIP.name(), service.getSpec().getType());
+                Assert.assertEquals(1, service.getSpec().getPorts().size());
+                Assert.assertEquals(8080, service.getSpec().getPorts().get(0).getPort().intValue());
+                Assert.assertEquals(9090, service.getSpec().getPorts().get(0).getTargetPort().getIntVal().intValue());
+            }
+        }
+    
+        validateDockerfile();
+        validateDockerImage(DOCKER_IMAGE);
+    
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
+    }
+    
     public void validateDockerfile() {
-        File dockerFile = new File(TARGET_PATH + File.separator + DOCKER + File.separator + "Dockerfile");
+        File dockerFile = TARGET_PATH.resolve(DOCKER).resolve("Dockerfile").toFile();
         Assert.assertTrue(dockerFile.exists());
     }
     
-    @Test
-    public void validateDockerImage() throws DockerTestException, InterruptedException {
-        List<String> ports = getExposedPorts(DOCKER_IMAGE);
+    public void validateDockerImage(String dockerImage) throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(dockerImage);
         Assert.assertEquals(ports.size(), 1);
         Assert.assertEquals(ports.get(0), "9090/tcp");
-    }
-    
-    @AfterClass
-    public void cleanUp() throws KubernetesPluginException, DockerTestException, InterruptedException {
-        KubernetesUtils.deleteDirectory(TARGET_PATH);
-        KubernetesTestUtils.deleteDockerImage(DOCKER_IMAGE);
     }
 }

--- a/kubernetes-extension-test/src/test/resources/svc/port_and_target_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/port_and_target_port.bal
@@ -1,0 +1,70 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerinax/kubernetes;
+
+
+public type SampleListener object {
+
+    *AbstractListener;
+
+    public function __start() returns error? {
+        return ();
+    }
+
+    public function __stop() returns error? {
+        return ();
+    }
+
+    public function __attach(service s, map<any> annotationData) returns error? {
+        return ();
+    }
+
+    public function __init() {}
+
+    public function initEndpoint() returns error? {
+        return ();
+    }
+
+    function register(service s, map<any> annotationData) returns error? {
+        return ();
+    }
+};
+
+@kubernetes:Deployment {
+    image: "pizza-shop:latest"
+}
+@kubernetes:Ingress {
+    hostname: "abc.com"
+}
+@kubernetes:Service {
+    name: "hello",
+    port: 8080,
+    targetPort: 9090
+}
+listener SampleListener helloEP = new();
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service helloWorld on helloEP {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        checkpanic outboundEP->respond(response);
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/svc/port_and_target_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/port_and_target_port.bal
@@ -17,30 +17,20 @@
 import ballerina/http;
 import ballerinax/kubernetes;
 
-
-public type SampleListener object {
+public type ABC object {
 
     *AbstractListener;
 
-    public function __start() returns error? {
-        return ();
+    public function __start() returns error?{
+        error e = error("startError");
+        panic e;
     }
 
     public function __stop() returns error? {
         return ();
     }
 
-    public function __attach(service s, map<any> annotationData) returns error? {
-        return ();
-    }
-
-    public function __init() {}
-
-    public function initEndpoint() returns error? {
-        return ();
-    }
-
-    function register(service s, map<any> annotationData) returns error? {
+    public function __attach(service s, string? name = ()) returns error? {
         return ();
     }
 };
@@ -56,12 +46,12 @@ public type SampleListener object {
     port: 8080,
     targetPort: 9090
 }
-listener SampleListener helloEP = new();
+listener ABC ep = new;
 
 @http:ServiceConfig {
     basePath: "/helloWorld"
 }
-service helloWorld on helloEP {
+service helloWorld on ep {
     resource function sayHello(http:Caller outboundEP, http:Request request) {
         http:Response response = new;
         response.setTextPayload("Hello, World from service helloWorld ! \n");

--- a/kubernetes-extension-test/src/test/resources/svc/port_and_target_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/port_and_target_port.bal
@@ -1,11 +1,11 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
@@ -193,6 +193,7 @@ public type ServiceType "NodePort"|"ClusterIP"|"LoadBalancer";
 public type ServiceConfiguration record {|
     *Metadata;
     int port?;
+    int targetPort?;
     SessionAffinity sessionAffinity = SESSION_AFFINITY_NONE;
     ServiceType serviceType = SERVICE_TYPE_CLUSTER_IP;
 |};

--- a/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/kubernetes/annotation.bal
@@ -188,6 +188,7 @@ public type ServiceType "NodePort"|"ClusterIP"|"LoadBalancer";
 # Kubernetes service configuration.
 #
 # + port - Service port
+# + targetPort - Port of the pods
 # + sessionAffinity - Session affinity for pods
 # + serviceType - Service type of the service
 public type ServiceConfiguration record {|

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/processors/ServiceAnnotationProcessor.java
@@ -72,7 +72,10 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         if (serviceModel.getPort() == -1) {
             serviceModel.setPort(extractPort(bListener));
         }
-        serviceModel.setTargetPort(extractPort(bListener));
+        
+        if (serviceModel.getTargetPort() == -1) {
+            serviceModel.setTargetPort(extractPort(bListener));
+        }
         KubernetesContext.getInstance().getDataHolder().addBListenerToK8sServiceMap(serviceNode.getName().getValue(),
                 serviceModel);
     }
@@ -93,7 +96,10 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         if (serviceModel.getPort() == -1) {
             serviceModel.setPort(extractPort(bListener));
         }
-        serviceModel.setTargetPort(extractPort(bListener));
+        
+        if (serviceModel.getTargetPort() == -1) {
+            serviceModel.setTargetPort(extractPort(bListener));
+        }
         KubernetesContext.getInstance().getDataHolder().addBListenerToK8sServiceMap(variableNode.getName().getValue()
                 , serviceModel);
     }
@@ -102,7 +108,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         try {
             return Integer.parseInt(bListener.argsExpr.get(0).toString());
         } catch (NumberFormatException e) {
-            throw new KubernetesPluginException("unable to parse port of the service: " +
+            throw new KubernetesPluginException("unable to parse port/targetPort for the service: " +
                                             bListener.argsExpr.get(0).toString());
         }
     }
@@ -132,6 +138,9 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
                 case port:
                     serviceModel.setPort(getIntValue(keyValue.getValue()));
                     break;
+                case targetPort:
+                    serviceModel.setTargetPort(getIntValue(keyValue.getValue()));
+                    break;
                 case sessionAffinity:
                     serviceModel.setSessionAffinity(getStringValue(keyValue.getValue()));
                     break;
@@ -151,6 +160,7 @@ public class ServiceAnnotationProcessor extends AbstractAnnotationProcessor {
         annotations,
         serviceType,
         port,
+        targetPort,
         sessionAffinity
     }
 }


### PR DESCRIPTION
## Purpose
> Allow users to set port and targetPort of a service than deriving from the listener. This is because users can have their own listeners.

## Goals
> Support custom listeners.
