### PR TITLE
Temporary fix for package file byte being empty

### DIFF
--- a/kubernetes-extension/src/main/ballerina/ballerinax/istio/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/istio/annotation.bal
@@ -14,8 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import kubernetes;
-
 # Types of protocols of a port.
 public type PortProtocol "HTTP"|"HTTPS"|"GRPC"|"HTTP2"|"MONGO"|"TCP"|"TLS";
 
@@ -63,10 +61,15 @@ public type ServerConfig record {|
 
 # Istio gateway annotation configuration.
 #
+# + name - Name of the resource
+# + labels - Map of labels for the resource
+# + annotations - Map of annotations for resource
 # + selector - Specific set of pods/VMs on which this gateway configuration should be applied.
 # + servers - List of servers to pass.
 public type GatewayConfig record {|
-    *kubernetes:Metadata;
+    string name?;
+    map<string> labels?;
+    map<string> annotations?;
     map<string> selector?;
     ServerConfig?[] servers?;
 |};
@@ -107,11 +110,16 @@ public type HTTPRouteConfig record {|
 
 # Virtual service configuration for @istio:VirtualService annotation.
 #
+# + name - Name of the resource
+# + labels - Map of labels for the resource
+# + annotations - Map of annotations for resource
 # + hosts - Destination which traffic should be sent.
 # + gateways - Names of the gateways which the service should listen to.
 # + http - Route rules for HTTP traffic.
 public type VirtualServiceConfig record {|
-    *kubernetes:Metadata;
+    string name?;
+    map<string> labels?;
+    map<string> annotations?;
     string[] hosts?;
     string[] gateways?;
     HTTPRouteConfig[] http?;

--- a/kubernetes-extension/src/main/ballerina/ballerinax/openshift/annotation.bal
+++ b/kubernetes-extension/src/main/ballerina/ballerinax/openshift/annotation.bal
@@ -14,8 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import kubernetes;
-
 public const string BUILD_EXTENSION_OPENSHIFT = "openshift";
 
 # Domain for OpenShift Route configuration.
@@ -27,9 +25,14 @@ public type RouteDomainConfig record {|
 
 # Route configuration for @kubernetes:OpenShiftRoute.
 #
+# + name - Name of the resource
+# + labels - Map of labels for the resource
+# + annotations - Map of annotations for resource
 # + host - The host of the route.
 public type RouteConfiguration record {|
-    *kubernetes:Metadata;
+    string name?;
+    map<string> labels?;
+    map<string> annotations?;
     string|RouteDomainConfig host;
 |};
 


### PR DESCRIPTION
## Purpose
> $subject.

To overcome the following error:
```
Compiling source
    ballerinax/kubernetes:0.0.0
    ballerinax/istio:0.0.0
    ballerinax/openshift:0.0.0
[WARNING] 
java.lang.NullPointerException
    at org.wso2.ballerinalang.programfile.PackageFileWriter.writePackage(PackageFileWriter.java:39)
    at org.wso2.ballerinalang.compiler.BinaryFileWriter.addPackageBinaryContent(BinaryFileWriter.java:207)
    at org.wso2.ballerinalang.compiler.BinaryFileWriter.writeLibraryPackage(BinaryFileWriter.java:156)
    at org.wso2.ballerinalang.compiler.BinaryFileWriter.writeLibraryPackage(BinaryFileWriter.java:129)
    at org.wso2.ballerinalang.compiler.BinaryFileWriter.write(BinaryFileWriter.java:90)
    at java.util.ArrayList.forEach(ArrayList.java:1249)
    at org.wso2.ballerinalang.compiler.Compiler.write(Compiler.java:112)
    at org.ballerinalang.stdlib.utils.GenerateBalo.genBalo(GenerateBalo.java:104)
    at org.ballerinalang.stdlib.utils.GenerateBalo.main(GenerateBalo.java:71)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:282)
    at java.lang.Thread.run(Thread.java:748)
```
