### PR TITLE
Allow setting a custom NodePort via service annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Annotation based kubernetes extension implementation for ballerina.
 |portName|Name for the port|The protocol of the listener|
 |port|Service port|Port of the ballerina service|
 |targetPort|Target pod(s) port|Port of the ballerina service|
+|nodePort|NodePort to expose service|None|
 |sessionAffinity|Pod session affinity|None|
 |serviceType|Service type of the service|ClusterIP|
 

--- a/kubernetes-extension-test/src/test/resources/svc/invalid_node_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/invalid_node_port.bal
@@ -25,8 +25,7 @@ import ballerina/kubernetes;
 }
 @kubernetes:Service {
     name: "hello",
-    nodePort: 31100,
-    serviceType: "NodePort"
+    nodePort: 31100
 }
 listener http:Listener helloEP = new(9090);
 

--- a/kubernetes-extension-test/src/test/resources/svc/invalid_node_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/invalid_node_port.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/kubernetes;
+
+@kubernetes:Deployment {
+    image: "pizza-shop:latest"
+}
+@kubernetes:Ingress {
+    hostname: "abc.com"
+}
+@kubernetes:Service {
+    name: "hello",
+    nodePort: 31100,
+    serviceType: "NodePort"
+}
+listener http:Listener helloEP = new(9090);
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service helloWorld on helloEP {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        checkpanic outboundEP->respond(response);
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/svc/node_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/node_port.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -25,7 +25,8 @@ import ballerina/kubernetes;
 }
 @kubernetes:Service {
     name: "hello",
-    port: 8080
+    nodePort: 31100,
+    serviceType: "NodePort"
 }
 listener http:Listener helloEP = new(9090);
 

--- a/kubernetes-extension-test/src/test/resources/svc/node_port.bal
+++ b/kubernetes-extension-test/src/test/resources/svc/node_port.bal
@@ -1,0 +1,41 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/kubernetes;
+
+@kubernetes:Deployment {
+    image: "pizza-shop:latest"
+}
+@kubernetes:Ingress {
+    hostname: "abc.com"
+}
+@kubernetes:Service {
+    name: "hello",
+    port: 8080
+}
+listener http:Listener helloEP = new(9090);
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service helloWorld on helloEP {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        checkpanic outboundEP->respond(response);
+    }
+}

--- a/kubernetes-extension/pom.xml
+++ b/kubernetes-extension/pom.xml
@@ -16,7 +16,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
         <groupId>org.ballerinax.kubernetes</groupId>
@@ -47,6 +48,11 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.snowdrop</groupId>

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/ServiceModel.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/models/ServiceModel.java
@@ -17,6 +17,8 @@
  */
 package org.ballerinax.kubernetes.models;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.ballerinax.kubernetes.KubernetesConstants;
 
 import java.util.HashMap;
@@ -24,91 +26,27 @@ import java.util.HashMap;
 /**
  * Kubernetes service annotations model class.
  */
+@EqualsAndHashCode(callSuper = true)
+@Data
 public class ServiceModel extends KubernetesModel {
     private String serviceType;
     private int port;
+    private int nodePort;
     private int targetPort;
     private String selector;
     private String sessionAffinity;
     private String portName;
     private String protocol;
-    
+
     public ServiceModel() {
         serviceType = KubernetesConstants.ServiceType.ClusterIP.name();
         labels = new HashMap<>();
         port = -1;
         targetPort = -1;
+        nodePort = -1;
     }
-    
+
     public void addLabel(String key, String value) {
         this.labels.put(key, value);
-    }
-
-    public String getServiceType() {
-        return serviceType;
-    }
-
-    public void setServiceType(String serviceType) {
-        this.serviceType = serviceType;
-    }
-    
-    public String getPortName() {
-        return portName;
-    }
-    
-    public void setPortName(String portName) {
-        this.portName = portName;
-    }
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-    
-    public String getProtocol() {
-        return protocol;
-    }
-    
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-    }
-    
-    public int getTargetPort() {
-        return targetPort;
-    }
-    
-    public void setTargetPort(int targetPort) {
-        this.targetPort = targetPort;
-    }
-    
-    public String getSelector() {
-        return selector;
-    }
-
-    public void setSelector(String selector) {
-        this.selector = selector;
-    }
-    
-    public String getSessionAffinity() {
-        return sessionAffinity;
-    }
-    
-    public void setSessionAffinity(String sessionAffinity) {
-        this.sessionAffinity = sessionAffinity;
-    }
-    
-    @Override
-    public String toString() {
-        return "ServiceModel{" +
-               "name='" + getName() + '\'' +
-               ", labels=" + labels +
-               ", serviceType='" + serviceType + '\'' +
-               ", sessionAffinity='" + sessionAffinity + '\'' +
-               ", portName='" + portName + '\'' +
-               ", port=" + port +
-               ", selector='" + selector + '\'' +
-               '}';
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>ballerina</artifactId>
@@ -151,6 +152,12 @@
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -273,6 +280,7 @@
         <spotify.docker.client.version>8.15.0</spotify.docker.client.version>
         <testng.version>6.14.3</testng.version>
         <slf4j.version>1.7.26</slf4j.version>
+        <lombok.version>1.18.10</lombok.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Purpose
- Allow setting a custom NodePort via service annotation
- Fixes ballerinax/kubernetes#407
- Depends on https://github.com/ballerina-platform/ballerina-lang/pull/20710