### PR TITLE
Fix syntax issues related to BFiniteType

### DIFF
--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KnativeUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KnativeUtils.java
@@ -367,8 +367,8 @@ public class KnativeUtils {
                         if (constantSymbol.type instanceof BFiniteType) {
                                 // Parse compile time constant
                                 BFiniteType compileConst = (BFiniteType) constantSymbol.type;
-                                if (compileConst.valueSpace.size() > 0) {
-                                    return resolveValue(compileConst.valueSpace.iterator().next().toString());
+                                if (compileConst.getValueSpace().size() > 0) {
+                                    return resolveValue(compileConst.getValueSpace().iterator().next().toString());
                                 }
                         }
                 }

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
@@ -375,8 +375,8 @@ public class KubernetesUtils {
                 if (constantSymbol.type instanceof BFiniteType) {
                     // Parse compile time constant
                     BFiniteType compileConst = (BFiniteType) constantSymbol.type;
-                    if (compileConst.valueSpace.size() > 0) {
-                        return resolveValue(compileConst.valueSpace.iterator().next().toString());
+                    if (compileConst.getValueSpace().size() > 0) {
+                        return resolveValue(compileConst.getValueSpace().iterator().next().toString());
                     }
                 }
             }


### PR DESCRIPTION
## Purpose
> $subject . `valueSpace` property of `BFiniteType` cannot be accessed now as there is a separate getter method to get it `getValueSpace()`

Resolves https://github.com/ballerinax/kubernetes/issues/484