### PR TITLE
Generate kubernetes artifacts with ballerina/kuberenetes import only

### DIFF
--- a/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/NoAnnotationsTest.java
+++ b/kubernetes-extension-test/src/test/java/org/ballerinax/kubernetes/test/NoAnnotationsTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.kubernetes.test;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.batch.Job;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.ballerinax.kubernetes.KubernetesConstants;
+import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.test.utils.DockerTestException;
+import org.ballerinax.kubernetes.test.utils.KubernetesTestUtils;
+import org.ballerinax.kubernetes.utils.KubernetesUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.ballerinax.kubernetes.KubernetesConstants.DOCKER;
+import static org.ballerinax.kubernetes.KubernetesConstants.KUBERNETES;
+import static org.ballerinax.kubernetes.test.utils.KubernetesTestUtils.getExposedPorts;
+
+/**
+ * Generate docker artifacts without @kubernetes annotations.
+ */
+public class NoAnnotationsTest {
+    private static final Path BAL_DIRECTORY = Paths.get("src", "test", "resources", "deployment", "no-annotations");
+    private static final Path DOCKER_TARGET_PATH = BAL_DIRECTORY.resolve(DOCKER);
+    private static final Path KUBERNETES_TARGET_PATH = BAL_DIRECTORY.resolve(KUBERNETES);
+    
+    @Test(timeOut = 90000)
+    public void serviceWithNoAnnotationTest() throws IOException, InterruptedException, DockerTestException,
+            KubernetesPluginException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_annotation_service.bal"), 0);
+        File yamlFile = KUBERNETES_TARGET_PATH.resolve("no_annotation_service.yaml").toFile();
+        Assert.assertTrue(yamlFile.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
+        for (HasMetadata data : k8sItems) {
+            if ("Service".equals(data.getKind())) {
+                Service service = (Service) data;
+                Assert.assertEquals(service.getMetadata().getName(), "helloworld-svc");
+                Assert.assertEquals(service.getMetadata().getLabels().get(KubernetesConstants
+                        .KUBERNETES_SELECTOR_KEY), "no_annotation_service");
+                Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+                Assert.assertEquals(service.getSpec().getPorts().size(), 1);
+                Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), 9090);
+            }
+            
+            if ("Deployment".equals(data.getKind())) {
+                Deployment deployment = (Deployment) data;
+                Assert.assertEquals(deployment.getMetadata().getName(), "no-annotation-service-deployment");
+                Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+                Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                        .KUBERNETES_SELECTOR_KEY), "no_annotation_service");
+                Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+                Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+                Assert.assertEquals(container.getImage(), "no_annotation_service:latest");
+                Assert.assertEquals(container.getImagePullPolicy(),
+                        KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+                Assert.assertEquals(container.getPorts().size(), 1);
+                Assert.assertEquals(container.getEnv().size(), 0);
+            }
+        }
+    
+        validateDockerfile();
+        validateDockerImage("no_annotation_service:latest");
+    
+        KubernetesUtils.deleteDirectory(KUBERNETES_TARGET_PATH);
+        KubernetesUtils.deleteDirectory(DOCKER_TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage("no_annotation_service:latest");
+    }
+    
+    @Test(timeOut = 90000)
+    public void listenerWithNoAnnotationTest() throws IOException, InterruptedException, DockerTestException,
+            KubernetesPluginException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_annotation_listener.bal"), 0);
+        File yamlFile = KUBERNETES_TARGET_PATH.resolve("no_annotation_listener.yaml").toFile();
+        Assert.assertTrue(yamlFile.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
+        for (HasMetadata data : k8sItems) {
+            if ("Service".equals(data.getKind())) {
+                Service service = (Service) data;
+                Assert.assertEquals(service.getMetadata().getName(), "helloworldep-svc");
+                Assert.assertEquals(service.getMetadata().getLabels().get(KubernetesConstants
+                        .KUBERNETES_SELECTOR_KEY), "no_annotation_listener");
+                Assert.assertEquals(service.getSpec().getType(), KubernetesConstants.ServiceType.ClusterIP.name());
+                Assert.assertEquals(service.getSpec().getPorts().size(), 1);
+                Assert.assertEquals(service.getSpec().getPorts().get(0).getPort().intValue(), 9090);
+            }
+            
+            if ("Deployment".equals(data.getKind())) {
+                Deployment deployment = (Deployment) data;
+                Assert.assertEquals(deployment.getMetadata().getName(), "no-annotation-listener-deployment");
+                Assert.assertEquals(deployment.getSpec().getReplicas().intValue(), 1);
+                Assert.assertEquals(deployment.getMetadata().getLabels().get(KubernetesConstants
+                        .KUBERNETES_SELECTOR_KEY), "no_annotation_listener");
+                Assert.assertEquals(deployment.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+                Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+                Assert.assertEquals(container.getImage(), "no_annotation_listener:latest");
+                Assert.assertEquals(container.getImagePullPolicy(),
+                        KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+                Assert.assertEquals(container.getPorts().size(), 1);
+                Assert.assertEquals(container.getEnv().size(), 0);
+            }
+        }
+        
+        validateDockerfile();
+        validateDockerImage("no_annotation_listener:latest");
+        
+        KubernetesUtils.deleteDirectory(KUBERNETES_TARGET_PATH);
+        KubernetesUtils.deleteDirectory(DOCKER_TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage("no_annotation_listener:latest");
+    }
+    
+    @Test(timeOut = 90000)
+    public void mainWithNoAnnotationTest() throws IOException, InterruptedException, DockerTestException,
+            KubernetesPluginException {
+        Assert.assertEquals(KubernetesTestUtils.compileBallerinaFile(BAL_DIRECTORY, "no_annotations_main.bal"), 0);
+        File yamlFile = KUBERNETES_TARGET_PATH.resolve("no_annotations_main.yaml").toFile();
+        Assert.assertTrue(yamlFile.exists());
+        KubernetesClient client = new DefaultKubernetesClient();
+        List<HasMetadata> k8sItems = client.load(new FileInputStream(yamlFile)).get();
+        for (HasMetadata data : k8sItems) {
+            if ("Job".equals(data.getKind())) {
+                Job job = (Job) data;
+                Assert.assertEquals(job.getMetadata().getName(), "no-annotations-main-job");
+                Assert.assertEquals(job.getSpec().getTemplate().getSpec().getContainers().size(), 1);
+    
+                Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
+                Assert.assertEquals(container.getImage(), "no_annotations_main:latest");
+                Assert.assertEquals(container.getImagePullPolicy(),
+                        KubernetesConstants.ImagePullPolicy.IfNotPresent.name());
+                Assert.assertEquals(job.getSpec().getTemplate().getSpec()
+                        .getRestartPolicy(), KubernetesConstants.RestartPolicy.Never.name());
+            }
+        }
+        
+        validateDockerfile();
+        
+        KubernetesUtils.deleteDirectory(KUBERNETES_TARGET_PATH);
+        KubernetesUtils.deleteDirectory(DOCKER_TARGET_PATH);
+        KubernetesTestUtils.deleteDockerImage("no_annotations_main:latest");
+    }
+    
+    public void validateDockerfile() {
+        File dockerFile = DOCKER_TARGET_PATH.resolve("Dockerfile").toFile();
+        Assert.assertTrue(dockerFile.exists());
+    }
+    
+    public void validateDockerImage(String dockerImage) throws DockerTestException, InterruptedException {
+        List<String> ports = getExposedPorts(dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotation_listener.bal
+++ b/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotation_listener.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/kubernetes as _;
+
+listener http:Listener helloWorldEP = new(9090);
+
+@http:ServiceConfig {
+      basePath: "/helloWorld"
+}
+service helloWorld on helloWorldEP {
+    resource function sayHello (http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World! \n");
+        var responseResult = outboundEP->respond(response);
+        if (responseResult is error) {
+            log:printError("error responding back to client.", responseResult);
+        }
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotation_service.bal
+++ b/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotation_service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/kubernetes as _;
+
+service helloWorld on new http:Listener(9090) {
+    // Resource functions are invoked with the HTTP caller and the incoming request as arguments.
+    resource function sayHello(http:Caller caller, http:Request req) {
+        // Send a response back to the caller.
+        var result = caller->respond("Hello, World!");
+        if (result is error) {
+            log:printError("Error sending response", result);
+        }
+    }
+}

--- a/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotations_main.bal
+++ b/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotations_main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotations_main.bal
+++ b/kubernetes-extension-test/src/test/resources/deployment/no-annotations/no_annotations_main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/kubernetes as _;
+
+public function main(string... args) {
+    io:println("hello world");
+}

--- a/kubernetes-extension-test/src/test/resources/testng-travis.xml
+++ b/kubernetes-extension-test/src/test/resources/testng-travis.xml
@@ -32,7 +32,6 @@
             <class name="org.ballerinax.kubernetes.test.samples.Sample11Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample12Test"/>
             <!--<class name="org.ballerinax.kubernetes.test.samples.Sample13Test"/> Need jdbc connector-->
-            <class name="org.ballerinax.kubernetes.test.samples.Sample18Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample14Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample15Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample16Test"/>
@@ -57,6 +56,7 @@
             <class name="org.ballerinax.kubernetes.test.IstioVirtualServiceTest"/>
             <class name="org.ballerinax.kubernetes.test.OpenShiftBuildConfigTest"/>
             <class name="org.ballerinax.kubernetes.test.OpenShiftRouteTest"/>
+            <class name="org.ballerinax.kubernetes.test.NoAnnotationsTest"/>
         </classes>
     </test>
 

--- a/kubernetes-extension-test/src/test/resources/testng.xml
+++ b/kubernetes-extension-test/src/test/resources/testng.xml
@@ -37,7 +37,6 @@
             <class name="org.ballerinax.kubernetes.test.samples.Sample11Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample12Test"/>
             <!--<class name="org.ballerinax.kubernetes.test.samples.Sample13Test"/> Need jdbc connector-->
-            <class name="org.ballerinax.kubernetes.test.samples.Sample18Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample14Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample15Test"/>
             <class name="org.ballerinax.kubernetes.test.samples.Sample16Test"/>
@@ -62,6 +61,7 @@
             <class name="org.ballerinax.kubernetes.test.IstioVirtualServiceTest"/>
             <class name="org.ballerinax.kubernetes.test.OpenShiftBuildConfigTest"/>
             <class name="org.ballerinax.kubernetes.test.OpenShiftRouteTest"/>
+            <class name="org.ballerinax.kubernetes.test.NoAnnotationsTest"/>
         </classes>
     </test>
 

--- a/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
+++ b/kubernetes-extension/src/main/java/org/ballerinax/kubernetes/utils/KubernetesUtils.java
@@ -31,6 +31,8 @@ import io.fabric8.kubernetes.api.model.ResourceFieldSelectorBuilder;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import org.apache.commons.io.FileUtils;
+import org.ballerinalang.model.tree.AnnotationAttachmentNode;
+import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
 import org.ballerinax.docker.generator.models.CopyFileModel;
@@ -46,6 +48,8 @@ import org.ballerinax.kubernetes.models.openshift.OpenShiftBuildExtensionModel;
 import org.ballerinax.kubernetes.processors.openshift.OpenShiftBuildExtensionProcessor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
@@ -622,5 +626,20 @@ public class KubernetesUtils {
     public static List<BLangRecordLiteral.BLangRecordKeyValueField> convertRecordFields(
             List<BLangRecordLiteral.RecordField> fields) {
         return fields.stream().map(f -> (BLangRecordLiteral.BLangRecordKeyValueField) f).collect(Collectors.toList());
+    }
+    
+    /**
+     * Create an annotation node.
+     *
+     * @param annotationName Name of the annotation node.
+     * @return The created node.
+     */
+    public static AnnotationAttachmentNode createAnnotation(String annotationName) {
+        AnnotationAttachmentNode configAnnotation = new BLangAnnotationAttachment();
+        IdentifierNode configIdentifier = new BLangIdentifier();
+        configIdentifier.setValue(annotationName);
+        configAnnotation.setAnnotationName(configIdentifier);
+        configAnnotation.setExpression(new BLangRecordLiteral());
+        return configAnnotation;
     }
 }


### PR DESCRIPTION
## Purpose
> $subject. Resolves https://github.com/ballerinax/kubernetes/issues/493

With this change it is possible to generate kubernetes artifacts by only including the kubernetes import as follows:
```ballerina
import ballerina/kubernetes as _;
```

Example: 
```ballerina
import ballerina/http;
import ballerina/log;
import ballerina/kubernetes as _;

listener http:Listener helloWorldEP = new(9090);

@http:ServiceConfig {
      basePath: "/helloWorld"
}
service helloWorld on helloWorldEP {
    resource function sayHello (http:Caller outboundEP, http:Request request) {
        http:Response response = new;
        response.setTextPayload("Hello, World! \n");
        var responseResult = outboundEP->respond(response);
        if (responseResult is error) {
            log:printError("error responding back to client.", responseResult);
        }
    }
}
```